### PR TITLE
Adopt Poetry tooling and dynamic environment selection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,27 +1,26 @@
 PYTHON ?= python3
+POETRY ?= poetry
 
 .PHONY: bootstrap lint test run-gateway run-evaluator compose-up compose-down
 
 bootstrap:
-	$(PYTHON) -m pip install -e libs/calculator_logic
-	$(PYTHON) -m pip install -e libs/calculator_core
-	$(PYTHON) -m pip install -e services/gateway
-	$(PYTHON) -m pip install -e services/safe_evaluator
+$(POETRY) -C services/gateway install
+$(POETRY) -C services/safe_evaluator install
 
 lint:
-	ruff check .
+$(POETRY) -C services/gateway run ruff check app ../safe_evaluator/app ../../libs
 
 test:
-	pytest
+$(POETRY) -C services/safe_evaluator run pytest ../../tests
 
 run-gateway:
-	uvicorn services.gateway.app.main:app --host 0.0.0.0 --port 8080 --reload
+$(POETRY) -C services/gateway run uvicorn app.main:app --host 0.0.0.0 --port 8080 --reload
 
 run-evaluator:
-	$(PYTHON) -m services.safe_evaluator.app.server
+$(POETRY) -C services/safe_evaluator run python -m app.server
 
 compose-up:
-	docker compose -f docker-compose.phase1.yml up --build
+docker compose -f docker-compose.phase1.yml up --build
 
 compose-down:
-	docker compose -f docker-compose.phase1.yml down
+docker compose -f docker-compose.phase1.yml down

--- a/services/gateway/app/config.py
+++ b/services/gateway/app/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from functools import lru_cache
 from pathlib import Path
 from typing import Optional
@@ -36,7 +37,11 @@ class ObservabilitySettings(BaseModel):
 
 
 class GatewaySettings(BaseSettings):
-    model_config = SettingsConfigDict(env_prefix="GATEWAY_", env_file=".env.development", env_file_encoding="utf-8")
+    model_config = SettingsConfigDict(
+        env_prefix="GATEWAY_",
+        env_nested_delimiter="__",
+        env_file_encoding="utf-8",
+    )
 
     host: str = "0.0.0.0"
     port: int = 8080
@@ -49,9 +54,6 @@ class GatewaySettings(BaseSettings):
     cache_pure_results: bool = True
     allowed_origins: list[str] = ["*"]
 
-    class Config:
-        env_nested_delimiter = "__"
-
 
 @lru_cache(maxsize=1)
 def get_settings() -> GatewaySettings:
@@ -59,7 +61,19 @@ def get_settings() -> GatewaySettings:
 
 
 def _resolve_env_file() -> Optional[Path]:
-    for candidate in (".env.development", ".env"):
+    explicit = os.getenv("GATEWAY_ENV_FILE")
+    if explicit:
+        path = Path(explicit)
+        if path.exists():
+            return path
+
+    env_name = os.getenv("GATEWAY_ENVIRONMENT") or os.getenv("ENVIRONMENT")
+    candidates: list[str] = []
+    if env_name:
+        candidates.append(f".env.{env_name.lower()}")
+    candidates.extend([".env.development", ".env"])
+
+    for candidate in candidates:
         path = Path(candidate)
         if path.exists():
             return path

--- a/services/gateway/pyproject.toml
+++ b/services/gateway/pyproject.toml
@@ -1,44 +1,36 @@
 [build-system]
-requires = ["setuptools>=68", "wheel"]
-build-backend = "setuptools.build_meta"
+requires = ["poetry-core>=1.9.0"]
+build-backend = "poetry.core.masonry.api"
 
-[project]
+[tool.poetry]
 name = "calculator-gateway"
 version = "0.1.0"
 description = "FastAPI gateway service for the calculator platform"
+authors = ["Calculator Platform Team"]
 readme = "README.md"
-requires-python = ">=3.10"
-authors = [{name = "Calculator Platform Team"}]
-classifiers = [
-  "Programming Language :: Python :: 3",
-  "Framework :: FastAPI",
-  "Topic :: Internet :: WWW/HTTP :: ASGI :: Application",
-]
-dependencies = [
-  "fastapi>=0.111.0",
-  "uvicorn[standard]>=0.30.0",
-  "pydantic-settings>=2.4.0",
-  "sqlalchemy[asyncio]>=2.0.0",
-  "asyncpg>=0.29.0",
-  "alembic>=1.12.0",
-  "redis>=5.0.0",
-  "prometheus-client>=0.20.0",
-  "prometheus-fastapi-instrumentator>=6.1.0",
-  "opentelemetry-api>=1.25.0",
-  "opentelemetry-sdk>=1.25.0",
-  "opentelemetry-instrumentation-fastapi>=0.46b0",
-  "python-json-logger>=2.0.7",
-  "httpx>=0.27.0",
-  {path = "../../libs/calculator_core", develop = true},
-  {path = "../../libs/calculator_logic", develop = true},
-]
+packages = [{ include = "app" }]
 
-[project.optional-dependencies]
-dev = [
-  "pytest",
-  "pytest-asyncio",
-  "respx",
-]
+[tool.poetry.dependencies]
+python = "^3.10"
+fastapi = "^0.111.0"
+uvicorn = {version = "^0.30.0", extras = ["standard"]}
+pydantic-settings = "^2.4.0"
+sqlalchemy = {version = "^2.0.0", extras = ["asyncio"]}
+asyncpg = "^0.29.0"
+alembic = "^1.12.0"
+redis = "^5.0.0"
+prometheus-client = "^0.20.0"
+prometheus-fastapi-instrumentator = "^6.1.0"
+opentelemetry-api = "^1.25.0"
+opentelemetry-sdk = "^1.25.0"
+opentelemetry-instrumentation-fastapi = "^0.46b0"
+python-json-logger = "^2.0.7"
+httpx = "^0.27.0"
+calculator-core = {path = "../../libs/calculator_core", develop = true}
+calculator-logic = {path = "../../libs/calculator_logic", develop = true}
 
-[tool.setuptools.packages.find]
-where = ["app"]
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.0.0"
+pytest-asyncio = "^0.23.0"
+respx = "^0.21.1"
+ruff = "^0.6.0"

--- a/services/safe_evaluator/app/config.py
+++ b/services/safe_evaluator/app/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from functools import lru_cache
 from pathlib import Path
 from typing import Optional
@@ -10,7 +11,10 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class EvaluatorSettings(BaseSettings):
-    model_config = SettingsConfigDict(env_prefix="EVALUATOR_", env_file=".env.development", env_file_encoding="utf-8")
+    model_config = SettingsConfigDict(
+        env_prefix="EVALUATOR_",
+        env_file_encoding="utf-8",
+    )
 
     host: str = "0.0.0.0"
     port: int = 50051
@@ -27,7 +31,19 @@ def get_settings() -> EvaluatorSettings:
 
 
 def _resolve_env_file() -> Optional[Path]:
-    for candidate in (".env.development", ".env"):
+    explicit = os.getenv("EVALUATOR_ENV_FILE")
+    if explicit:
+        path = Path(explicit)
+        if path.exists():
+            return path
+
+    env_name = os.getenv("EVALUATOR_ENVIRONMENT") or os.getenv("ENVIRONMENT")
+    candidates: list[str] = []
+    if env_name:
+        candidates.append(f".env.{env_name.lower()}")
+    candidates.extend([".env.development", ".env"])
+
+    for candidate in candidates:
         path = Path(candidate)
         if path.exists():
             return path

--- a/services/safe_evaluator/pyproject.toml
+++ b/services/safe_evaluator/pyproject.toml
@@ -1,31 +1,28 @@
 [build-system]
-requires = ["setuptools>=68", "wheel"]
-build-backend = "setuptools.build_meta"
+requires = ["poetry-core>=1.9.0"]
+build-backend = "poetry.core.masonry.api"
 
-[project]
+[tool.poetry]
 name = "calculator-safe-evaluator"
 version = "0.1.0"
 description = "Sandboxed evaluator microservice"
+authors = ["Calculator Platform Team"]
 readme = "README.md"
-requires-python = ">=3.10"
-authors = [{name = "Calculator Platform Team"}]
-classifiers = [
-  "Programming Language :: Python :: 3",
-  "Topic :: Scientific/Engineering :: Mathematics",
-]
-dependencies = [
-  "pydantic-settings>=2.4.0",
-  "opentelemetry-api>=1.25.0",
-  "opentelemetry-sdk>=1.25.0",
-  "opentelemetry-instrumentation-grpc>=0.46b0",
-  "python-json-logger>=2.0.7",
-  "asteval>=1.0.6",
-  {path = "../../libs/calculator_core", develop = true},
-  {path = "../../libs/calculator_logic", develop = true},
-]
+packages = [{ include = "app" }]
 
-[project.optional-dependencies]
-dev = ["pytest", "pytest-asyncio"]
+[tool.poetry.dependencies]
+python = "^3.10"
+pydantic-settings = "^2.4.0"
+opentelemetry-api = "^1.25.0"
+opentelemetry-sdk = "^1.25.0"
+opentelemetry-instrumentation-grpc = "^0.46b0"
+python-json-logger = "^2.0.7"
+asteval = "^1.0.6"
+grpcio = "^1.64.1"
+calculator-core = {path = "../../libs/calculator_core", develop = true}
+calculator-logic = {path = "../../libs/calculator_logic", develop = true}
 
-[tool.setuptools.packages.find]
-where = ["app"]
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.0.0"
+pytest-asyncio = "^0.23.0"
+ruff = "^0.6.0"


### PR DESCRIPTION
## Summary
- convert the gateway and safe evaluator service projects to Poetry configuration with development dependency groups
- update the Pydantic settings helpers to resolve environment files via service-specific environment variables
- refresh the root Makefile to bootstrap, lint, test, and run services through Poetry-managed virtual environments

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e087f0e5b0832db3a554a116a255ec