### PR TITLE
Implement sandboxed safe evaluator with allowlist refresh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,27 +1,26 @@
 PYTHON ?= python3
+POETRY ?= poetry
 
 .PHONY: bootstrap lint test run-gateway run-evaluator compose-up compose-down
 
 bootstrap:
-	$(PYTHON) -m pip install -e libs/calculator_logic
-	$(PYTHON) -m pip install -e libs/calculator_core
-	$(PYTHON) -m pip install -e services/gateway
-	$(PYTHON) -m pip install -e services/safe_evaluator
+$(POETRY) -C services/gateway install
+$(POETRY) -C services/safe_evaluator install
 
 lint:
-	ruff check .
+$(POETRY) -C services/gateway run ruff check app ../safe_evaluator/app ../../libs
 
 test:
-	pytest
+$(POETRY) -C services/safe_evaluator run pytest ../../tests
 
 run-gateway:
-	uvicorn services.gateway.app.main:app --host 0.0.0.0 --port 8080 --reload
+$(POETRY) -C services/gateway run uvicorn app.main:app --host 0.0.0.0 --port 8080 --reload
 
 run-evaluator:
-	$(PYTHON) -m services.safe_evaluator.app.server
+$(POETRY) -C services/safe_evaluator run python -m app.server
 
 compose-up:
-	docker compose -f docker-compose.phase1.yml up --build
+docker compose -f docker-compose.phase1.yml up --build
 
 compose-down:
-	docker compose -f docker-compose.phase1.yml down
+docker compose -f docker-compose.phase1.yml down

--- a/libs/calculator_core/src/calculator_core/__init__.py
+++ b/libs/calculator_core/src/calculator_core/__init__.py
@@ -1,14 +1,20 @@
 """Sandbox and validation utilities shared across calculator services."""
 
+from .allowlist import DEFAULT_SYMBOLS, default_allowlist, filter_allowlist, merge_allowlist
 from .ast_guard import ExpressionValidator, ValidationError
+from .complexity import ComplexityBudget, ComplexityMetrics
 from .sandbox import SandboxConfig, SandboxResult, SandboxRunner
-from .complexity import ComplexityBudget
 
 __all__ = [
+    "DEFAULT_SYMBOLS",
     "ExpressionValidator",
     "ValidationError",
     "SandboxConfig",
     "SandboxResult",
     "SandboxRunner",
     "ComplexityBudget",
+    "ComplexityMetrics",
+    "default_allowlist",
+    "filter_allowlist",
+    "merge_allowlist",
 ]

--- a/libs/calculator_core/src/calculator_core/allowlist.py
+++ b/libs/calculator_core/src/calculator_core/allowlist.py
@@ -1,0 +1,76 @@
+"""Utilities for managing calculator sandbox allow lists."""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, Mapping
+
+from calculator_logic import (
+    ABSOLUTE_FUNCTIONS,
+    LOG_FUNCTIONS,
+    TRIGONOMETRIC_FUNCTIONS,
+    add,
+    divide,
+    factorial,
+    multiply,
+    power,
+    round_number,
+    sqrt,
+    subtract,
+)
+
+DEFAULT_SYMBOLS: Dict[str, object] = {
+    "add": add,
+    "subtract": subtract,
+    "multiply": multiply,
+    "divide": divide,
+    "power": power,
+    "sqrt": sqrt,
+    "factorial": factorial,
+    "round": round_number,
+    "round_number": round_number,
+}
+DEFAULT_SYMBOLS.update(TRIGONOMETRIC_FUNCTIONS)
+DEFAULT_SYMBOLS.update(LOG_FUNCTIONS)
+DEFAULT_SYMBOLS.update(ABSOLUTE_FUNCTIONS)
+
+
+def default_allowlist() -> Dict[str, object]:
+    """Return a copy of the default symbol allow list."""
+
+    return dict(DEFAULT_SYMBOLS)
+
+
+def filter_allowlist(symbols: Iterable[str]) -> Dict[str, object]:
+    """Return a filtered allow list restricted to *symbols*."""
+
+    filtered: Dict[str, object] = {}
+    missing: list[str] = []
+    for name in symbols:
+        if name in DEFAULT_SYMBOLS:
+            filtered[name] = DEFAULT_SYMBOLS[name]
+        else:
+            missing.append(name)
+    if missing:
+        available = ", ".join(sorted(DEFAULT_SYMBOLS))
+        missing_str = ", ".join(sorted(missing))
+        raise ValueError(
+            f"Unknown allow list symbol(s): {missing_str}. Available symbols: {available}"
+        )
+    if not filtered:
+        raise ValueError("Allow list must contain at least one permitted symbol")
+    return filtered
+
+
+def merge_allowlist(overrides: Mapping[str, object] | None = None) -> Dict[str, object]:
+    """Return the default allow list merged with *overrides* if provided."""
+
+    allowlist = default_allowlist()
+    if overrides:
+        for name, value in overrides.items():
+            if name not in DEFAULT_SYMBOLS:
+                raise ValueError(f"Override {name!r} is not a permitted calculator function")
+            allowlist[name] = value
+    return allowlist
+
+
+__all__ = ["DEFAULT_SYMBOLS", "default_allowlist", "filter_allowlist", "merge_allowlist"]

--- a/libs/calculator_core/src/calculator_core/ast_guard.py
+++ b/libs/calculator_core/src/calculator_core/ast_guard.py
@@ -17,23 +17,35 @@ class ExpressionValidator:
 
     allowed_nodes: Set[type]
     banned_names: Set[str]
+    max_length: int = 512
 
-    def validate(self, expression: str) -> ast.AST:
+    def validate(
+        self,
+        expression: str,
+        allowed_identifiers: Iterable[str] | None = None,
+    ) -> ast.AST:
         if not expression:
             raise ValidationError("Expression cannot be empty")
-        if len(expression) > 512:
-            raise ValidationError("Expression length exceeds maximum of 512 characters")
+        if len(expression) > self.max_length:
+            raise ValidationError(
+                f"Expression length exceeds maximum of {self.max_length} characters"
+            )
 
         try:
             tree = ast.parse(expression, mode="eval")
         except SyntaxError as exc:
             raise ValidationError(f"Invalid expression syntax: {exc.msg}") from exc
 
+        allowed_names = set(allowed_identifiers or ())
+
         for node in ast.walk(tree):
             if type(node) not in self.allowed_nodes:
                 raise ValidationError(f"Node {type(node).__name__} is not permitted")
-            if isinstance(node, ast.Name) and node.id in self.banned_names:
-                raise ValidationError(f"Name {node.id!r} is not permitted")
+            if isinstance(node, ast.Name):
+                if node.id in self.banned_names:
+                    raise ValidationError(f"Name {node.id!r} is not permitted")
+                if allowed_names and node.id not in allowed_names:
+                    raise ValidationError(f"Identifier {node.id!r} is not permitted")
             if isinstance(node, ast.Call):
                 if isinstance(node.func, ast.Attribute):
                     raise ValidationError("Attribute access is not permitted")

--- a/libs/calculator_core/src/calculator_core/complexity.py
+++ b/libs/calculator_core/src/calculator_core/complexity.py
@@ -7,14 +7,22 @@ from dataclasses import dataclass
 
 
 @dataclass(slots=True)
+class ComplexityMetrics:
+    depth: int
+    nodes: int
+    score: int
+
+
+@dataclass(slots=True)
 class ComplexityBudget:
     """Simple heuristic scoring for AST complexity."""
 
     max_depth: int
     max_nodes: int
+    max_score: int
 
-    def score(self, tree: ast.AST) -> tuple[int, int]:
-        """Return the depth and number of nodes for *tree*."""
+    def score(self, tree: ast.AST) -> ComplexityMetrics:
+        """Return complexity metrics for *tree*."""
 
         max_depth = 0
         total_nodes = 0
@@ -27,11 +35,21 @@ class ComplexityBudget:
                 walk(child, depth + 1)
 
         walk(tree, 1)
-        return max_depth, total_nodes
+        score = max_depth * max_depth + total_nodes
+        return ComplexityMetrics(depth=max_depth, nodes=total_nodes, score=score)
 
-    def validate(self, tree: ast.AST) -> None:
-        depth, nodes = self.score(tree)
-        if depth > self.max_depth:
-            raise ValueError(f"AST depth {depth} exceeds limit {self.max_depth}")
-        if nodes > self.max_nodes:
-            raise ValueError(f"AST node count {nodes} exceeds limit {self.max_nodes}")
+    def validate(self, tree: ast.AST) -> ComplexityMetrics:
+        metrics = self.score(tree)
+        if metrics.depth > self.max_depth:
+            raise ValueError(
+                f"AST depth {metrics.depth} exceeds limit {self.max_depth}"
+            )
+        if metrics.nodes > self.max_nodes:
+            raise ValueError(
+                f"AST node count {metrics.nodes} exceeds limit {self.max_nodes}"
+            )
+        if metrics.score > self.max_score:
+            raise ValueError(
+                f"AST complexity score {metrics.score} exceeds limit {self.max_score}"
+            )
+        return metrics

--- a/libs/calculator_core/src/calculator_core/sandbox.py
+++ b/libs/calculator_core/src/calculator_core/sandbox.py
@@ -12,19 +12,7 @@ from typing import Any, Dict, Mapping, Optional
 
 from asteval import Interpreter
 
-from calculator_logic import (
-    ABSOLUTE_FUNCTIONS,
-    LOG_FUNCTIONS,
-    TRIGONOMETRIC_FUNCTIONS,
-    add,
-    divide,
-    factorial,
-    multiply,
-    power,
-    round_number,
-    sqrt,
-    subtract,
-)
+from .allowlist import default_allowlist
 
 
 @dataclass(slots=True)
@@ -47,12 +35,24 @@ class SandboxRunner:
 
     def __init__(self, config: SandboxConfig | None = None) -> None:
         self._config = config or SandboxConfig()
+        self._ctx = mp.get_context("spawn")
 
-    def run(self, expression: str, context: Mapping[str, Any] | None = None) -> SandboxResult:
+    def run(
+        self,
+        expression: str,
+        context: Mapping[str, Any] | None = None,
+        allowed_symbols: Mapping[str, object] | None = None,
+    ) -> SandboxResult:
         parent_conn, child_conn = mp.Pipe()
-        process = mp.Process(
+        process = self._ctx.Process(
             target=_worker,
-            args=(child_conn, expression, dict(context or {}), self._config),
+            args=(
+                child_conn,
+                expression,
+                dict(context or {}),
+                dict(allowed_symbols or {}),
+                self._config,
+            ),
             daemon=True,
         )
         start = time.perf_counter()
@@ -80,15 +80,23 @@ class SandboxRunner:
         return SandboxResult(True, float(value), None, duration_ms)
 
 
-def _worker(conn: Connection, expression: str, context: Dict[str, Any], config: SandboxConfig) -> None:
+def _worker(
+    conn: Connection,
+    expression: str,
+    context: Dict[str, Any],
+    allowed_symbols: Dict[str, object],
+    config: SandboxConfig,
+) -> None:
     try:
         resource.setrlimit(resource.RLIMIT_AS, (config.max_memory_bytes, config.max_memory_bytes))
+        cpu_seconds = max(1, math.ceil(config.max_runtime_seconds))
+        resource.setrlimit(resource.RLIMIT_CPU, (cpu_seconds, cpu_seconds))
     except (ValueError, OSError):
         # Ignore platforms that do not support RLIMIT_AS.
         pass
 
     try:
-        result = _evaluate(expression, context)
+        result = _evaluate(expression, context, allowed_symbols)
     except Exception as exc:  # noqa: BLE001
         conn.send({"ok": False, "error": str(exc)})
     else:
@@ -97,35 +105,33 @@ def _worker(conn: Connection, expression: str, context: Dict[str, Any], config: 
         conn.close()
 
 
-def _evaluate(expression: str, context: Mapping[str, Any]) -> float:
+def _evaluate(
+    expression: str,
+    context: Mapping[str, Any],
+    allowed_symbols: Mapping[str, object],
+) -> float:
     interpreter = Interpreter(use_numpy=False)
     interpreter.symtable.clear()
+    interpreter.symtable["__builtins__"] = {}
 
-    interpreter.symtable.update(
-        {
-            "add": add,
-            "subtract": subtract,
-            "multiply": multiply,
-            "divide": divide,
-            "power": power,
-            "sqrt": sqrt,
-            "factorial": factorial,
-            "round": round_number,
-        }
-    )
-    interpreter.symtable.update(TRIGONOMETRIC_FUNCTIONS)
-    interpreter.symtable.update(LOG_FUNCTIONS)
-    interpreter.symtable.update(ABSOLUTE_FUNCTIONS)
+    if allowed_symbols:
+        symbols = dict(allowed_symbols)
+    else:
+        symbols = default_allowlist()
+
+    interpreter.symtable.update(symbols)
 
     sanitized_context: Dict[str, float] = {}
     for key, value in context.items():
         if not key.isidentifier():
             raise ValueError(f"Context key {key!r} is not a valid identifier")
+        if key in interpreter.symtable:
+            raise ValueError(f"Context key {key!r} collides with a reserved symbol")
         sanitized_context[key] = float(value)
     interpreter.symtable.update(sanitized_context)
 
     value = interpreter(expression)
     if interpreter.error:
-        message = ", ".join(err.get_error() for err in interpreter.error)
+        message = ", ".join(str(err.get_error()) for err in interpreter.error)
         raise ValueError(message)
     return float(value)

--- a/services/gateway/app/config.py
+++ b/services/gateway/app/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from functools import lru_cache
 from pathlib import Path
 from typing import Optional
@@ -36,7 +37,11 @@ class ObservabilitySettings(BaseModel):
 
 
 class GatewaySettings(BaseSettings):
-    model_config = SettingsConfigDict(env_prefix="GATEWAY_", env_file=".env.development", env_file_encoding="utf-8")
+    model_config = SettingsConfigDict(
+        env_prefix="GATEWAY_",
+        env_nested_delimiter="__",
+        env_file_encoding="utf-8",
+    )
 
     host: str = "0.0.0.0"
     port: int = 8080
@@ -49,9 +54,6 @@ class GatewaySettings(BaseSettings):
     cache_pure_results: bool = True
     allowed_origins: list[str] = ["*"]
 
-    class Config:
-        env_nested_delimiter = "__"
-
 
 @lru_cache(maxsize=1)
 def get_settings() -> GatewaySettings:
@@ -59,7 +61,19 @@ def get_settings() -> GatewaySettings:
 
 
 def _resolve_env_file() -> Optional[Path]:
-    for candidate in (".env.development", ".env"):
+    explicit = os.getenv("GATEWAY_ENV_FILE")
+    if explicit:
+        path = Path(explicit)
+        if path.exists():
+            return path
+
+    env_name = os.getenv("GATEWAY_ENVIRONMENT") or os.getenv("ENVIRONMENT")
+    candidates: list[str] = []
+    if env_name:
+        candidates.append(f".env.{env_name.lower()}")
+    candidates.extend([".env.development", ".env"])
+
+    for candidate in candidates:
         path = Path(candidate)
         if path.exists():
             return path

--- a/services/gateway/pyproject.toml
+++ b/services/gateway/pyproject.toml
@@ -1,44 +1,36 @@
 [build-system]
-requires = ["setuptools>=68", "wheel"]
-build-backend = "setuptools.build_meta"
+requires = ["poetry-core>=1.9.0"]
+build-backend = "poetry.core.masonry.api"
 
-[project]
+[tool.poetry]
 name = "calculator-gateway"
 version = "0.1.0"
 description = "FastAPI gateway service for the calculator platform"
+authors = ["Calculator Platform Team"]
 readme = "README.md"
-requires-python = ">=3.10"
-authors = [{name = "Calculator Platform Team"}]
-classifiers = [
-  "Programming Language :: Python :: 3",
-  "Framework :: FastAPI",
-  "Topic :: Internet :: WWW/HTTP :: ASGI :: Application",
-]
-dependencies = [
-  "fastapi>=0.111.0",
-  "uvicorn[standard]>=0.30.0",
-  "pydantic-settings>=2.4.0",
-  "sqlalchemy[asyncio]>=2.0.0",
-  "asyncpg>=0.29.0",
-  "alembic>=1.12.0",
-  "redis>=5.0.0",
-  "prometheus-client>=0.20.0",
-  "prometheus-fastapi-instrumentator>=6.1.0",
-  "opentelemetry-api>=1.25.0",
-  "opentelemetry-sdk>=1.25.0",
-  "opentelemetry-instrumentation-fastapi>=0.46b0",
-  "python-json-logger>=2.0.7",
-  "httpx>=0.27.0",
-  {path = "../../libs/calculator_core", develop = true},
-  {path = "../../libs/calculator_logic", develop = true},
-]
+packages = [{ include = "app" }]
 
-[project.optional-dependencies]
-dev = [
-  "pytest",
-  "pytest-asyncio",
-  "respx",
-]
+[tool.poetry.dependencies]
+python = "^3.10"
+fastapi = "^0.111.0"
+uvicorn = {version = "^0.30.0", extras = ["standard"]}
+pydantic-settings = "^2.4.0"
+sqlalchemy = {version = "^2.0.0", extras = ["asyncio"]}
+asyncpg = "^0.29.0"
+alembic = "^1.12.0"
+redis = "^5.0.0"
+prometheus-client = "^0.20.0"
+prometheus-fastapi-instrumentator = "^6.1.0"
+opentelemetry-api = "^1.25.0"
+opentelemetry-sdk = "^1.25.0"
+opentelemetry-instrumentation-fastapi = "^0.46b0"
+python-json-logger = "^2.0.7"
+httpx = "^0.27.0"
+calculator-core = {path = "../../libs/calculator_core", develop = true}
+calculator-logic = {path = "../../libs/calculator_logic", develop = true}
 
-[tool.setuptools.packages.find]
-where = ["app"]
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.0.0"
+pytest-asyncio = "^0.23.0"
+respx = "^0.21.1"
+ruff = "^0.6.0"

--- a/services/safe_evaluator/app/allowlist.json
+++ b/services/safe_evaluator/app/allowlist.json
@@ -1,0 +1,20 @@
+{
+  "functions": [
+    "add",
+    "subtract",
+    "multiply",
+    "divide",
+    "power",
+    "sqrt",
+    "factorial",
+    "round",
+    "round_number",
+    "sin",
+    "cos",
+    "tan",
+    "log",
+    "log10",
+    "abs",
+    "absolute"
+  ]
+}

--- a/services/safe_evaluator/app/allowlist.py
+++ b/services/safe_evaluator/app/allowlist.py
@@ -1,0 +1,88 @@
+"""Allow list management for the evaluator sandbox."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from threading import Lock
+from typing import Dict, Optional, Set
+
+from calculator_core import default_allowlist, filter_allowlist
+
+logger = logging.getLogger(__name__)
+
+
+class AllowListError(RuntimeError):
+    """Raised when the allow list configuration cannot be loaded."""
+
+
+@dataclass(slots=True)
+class AllowListSnapshot:
+    symbols: Dict[str, object]
+    names: Set[str]
+
+
+class AllowListManager:
+    """Load the allow list from disk and refresh when it changes."""
+
+    def __init__(self, path: Optional[Path]) -> None:
+        self._path = path
+        self._lock = Lock()
+        self._symbols: Dict[str, object] = default_allowlist()
+        self._names: Set[str] = set(self._symbols)
+        self._mtime: float | None = None
+
+        if self._path is not None:
+            self._path = self._path.expanduser().resolve()
+
+    def snapshot(self) -> AllowListSnapshot:
+        self._refresh_if_needed()
+        with self._lock:
+            return AllowListSnapshot(symbols=dict(self._symbols), names=set(self._names))
+
+    def _refresh_if_needed(self) -> None:
+        if self._path is None:
+            return
+
+        try:
+            stat = self._path.stat()
+        except FileNotFoundError:
+            with self._lock:
+                if self._mtime is not None:
+                    logger.warning(
+                        "Allow list file %s disappeared; reverting to defaults", self._path
+                    )
+                self._symbols = default_allowlist()
+                self._names = set(self._symbols)
+                self._mtime = None
+            return
+
+        if self._mtime is not None and stat.st_mtime <= self._mtime:
+            return
+
+        try:
+            payload = json.loads(self._path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:  # pragma: no cover - configuration error path
+            raise AllowListError(f"Failed to parse allow list JSON: {exc.msg}") from exc
+
+        functions = payload.get("functions")
+        if not isinstance(functions, list):
+            raise AllowListError("Allow list file must contain a 'functions' array")
+
+        try:
+            symbols = filter_allowlist(functions)
+        except ValueError as exc:
+            raise AllowListError(str(exc)) from exc
+
+        with self._lock:
+            self._symbols = symbols
+            self._names = set(symbols)
+            self._mtime = stat.st_mtime
+            logger.info(
+                "Loaded allow list", extra={"path": str(self._path), "symbols": sorted(self._names)}
+            )
+
+
+__all__ = ["AllowListError", "AllowListManager", "AllowListSnapshot"]

--- a/services/safe_evaluator/app/config.py
+++ b/services/safe_evaluator/app/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from functools import lru_cache
 from pathlib import Path
 from typing import Optional
@@ -10,13 +11,20 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class EvaluatorSettings(BaseSettings):
-    model_config = SettingsConfigDict(env_prefix="EVALUATOR_", env_file=".env.development", env_file_encoding="utf-8")
+    model_config = SettingsConfigDict(
+        env_prefix="EVALUATOR_",
+        env_file_encoding="utf-8",
+    )
 
     host: str = "0.0.0.0"
     port: int = 50051
     max_runtime_seconds: float = 0.25
     max_result_magnitude: float = 1e12
     max_memory_bytes: int = 64 * 1024 * 1024
+    max_ast_depth: int = 25
+    max_ast_nodes: int = 128
+    max_complexity_score: int = 1024
+    allowlist_path: Optional[Path] = Path(__file__).with_name("allowlist.json")
     otlp_endpoint: Optional[str] = None
     log_level: str = "INFO"
 
@@ -27,7 +35,19 @@ def get_settings() -> EvaluatorSettings:
 
 
 def _resolve_env_file() -> Optional[Path]:
-    for candidate in (".env.development", ".env"):
+    explicit = os.getenv("EVALUATOR_ENV_FILE")
+    if explicit:
+        path = Path(explicit)
+        if path.exists():
+            return path
+
+    env_name = os.getenv("EVALUATOR_ENVIRONMENT") or os.getenv("ENVIRONMENT")
+    candidates: list[str] = []
+    if env_name:
+        candidates.append(f".env.{env_name.lower()}")
+    candidates.extend([".env.development", ".env"])
+
+    for candidate in candidates:
         path = Path(candidate)
         if path.exists():
             return path

--- a/services/safe_evaluator/app/server.py
+++ b/services/safe_evaluator/app/server.py
@@ -11,6 +11,7 @@ from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExport
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter, SimpleSpanProcessor
+from pythonjsonlogger import jsonlogger
 
 from .config import EvaluatorSettings, get_settings
 from .service import EvaluatorService
@@ -20,7 +21,14 @@ logger = logging.getLogger(__name__)
 
 
 def configure_logging(level: str) -> None:
-    logging.basicConfig(level=getattr(logging, level.upper(), logging.INFO))
+    handler = logging.StreamHandler()
+    handler.setFormatter(
+        jsonlogger.JsonFormatter("%(asctime)s %(levelname)s %(name)s %(message)s")
+    )
+    root = logging.getLogger()
+    root.handlers.clear()
+    root.addHandler(handler)
+    root.setLevel(getattr(logging, level.upper(), logging.INFO))
 
 
 def configure_tracing(settings: EvaluatorSettings) -> None:
@@ -43,7 +51,7 @@ async def serve() -> None:
     evaluator = EvaluatorService(settings)
     evaluator_pb2_grpc.add_EvaluatorServicer_to_server(evaluator, server)
     server.add_insecure_port(f"{settings.host}:{settings.port}")
-    logger.info("Starting evaluator on %s:%s", settings.host, settings.port)
+    logger.info("Starting evaluator", extra={"host": settings.host, "port": settings.port})
     await server.start()
     await server.wait_for_termination()
 

--- a/services/safe_evaluator/app/service.py
+++ b/services/safe_evaluator/app/service.py
@@ -3,13 +3,22 @@
 from __future__ import annotations
 
 import logging
+import time
 from typing import Dict
 
 import grpc
 
-from calculator_core import ComplexityBudget, ExpressionValidator, SandboxConfig, SandboxRunner
+from calculator_core import (
+    ComplexityBudget,
+    ComplexityMetrics,
+    ExpressionValidator,
+    SandboxConfig,
+    SandboxRunner,
+    ValidationError,
+)
 from services.protos import evaluator_pb2, evaluator_pb2_grpc
 
+from .allowlist import AllowListError, AllowListManager
 from .config import EvaluatorSettings
 
 logger = logging.getLogger(__name__)
@@ -19,7 +28,11 @@ class EvaluatorService(evaluator_pb2_grpc.EvaluatorServicer):
     def __init__(self, settings: EvaluatorSettings) -> None:
         self._settings = settings
         self._validator = ExpressionValidator.default()
-        self._budget = ComplexityBudget(max_depth=25, max_nodes=128)
+        self._budget = ComplexityBudget(
+            max_depth=settings.max_ast_depth,
+            max_nodes=settings.max_ast_nodes,
+            max_score=settings.max_complexity_score,
+        )
         self._sandbox = SandboxRunner(
             SandboxConfig(
                 max_runtime_seconds=settings.max_runtime_seconds,
@@ -27,27 +40,67 @@ class EvaluatorService(evaluator_pb2_grpc.EvaluatorServicer):
                 max_memory_bytes=settings.max_memory_bytes,
             )
         )
+        self._allowlist = AllowListManager(settings.allowlist_path)
 
     async def Evaluate(
         self,
         request: evaluator_pb2.EvaluateRequest,
         context: grpc.ServicerContext,
     ) -> evaluator_pb2.EvaluateResponse:
-        logger.debug("Received evaluation request", extra={"expression": request.expression})
-        try:
-            tree = self._validator.validate(request.expression)
-            self._budget.validate(tree)
-        except ValueError as exc:
-            await context.abort(grpc.StatusCode.INVALID_ARGUMENT, str(exc))
+        start_time = time.perf_counter()
+        logger.debug(
+            "Received evaluation request",
+            extra={"expression": request.expression, "context_keys": list(request.context.keys())},
+        )
 
         try:
-            sandbox_result = self._sandbox.run(request.expression, _sanitize_context(request.context))
-        except Exception as exc:  # noqa: BLE001
-            logger.exception("Sandbox execution failed")
-            await context.abort(grpc.StatusCode.INTERNAL, str(exc))
+            snapshot = self._allowlist.snapshot()
+        except AllowListError as exc:
+            logger.error("Allow list load failed", exc_info=exc)
+            duration_ms = (time.perf_counter() - start_time) * 1000.0
+            return evaluator_pb2.EvaluateResponse(error=str(exc), duration_ms=duration_ms)
+
+        try:
+            sanitized_context = _sanitize_context(request.context, snapshot.names)
+        except ValueError as exc:
+            duration_ms = (time.perf_counter() - start_time) * 1000.0
+            logger.info("Context validation failed", extra={"error": str(exc)})
+            return evaluator_pb2.EvaluateResponse(error=str(exc), duration_ms=duration_ms)
+
+        allowed_identifiers = snapshot.names | set(sanitized_context.keys())
+
+        try:
+            tree = self._validator.validate(
+                request.expression,
+                allowed_identifiers=allowed_identifiers,
+            )
+            metrics = self._budget.validate(tree)
+        except ValidationError as exc:
+            duration_ms = (time.perf_counter() - start_time) * 1000.0
+            logger.info("Expression validation failed", extra={"error": str(exc)})
+            return evaluator_pb2.EvaluateResponse(error=str(exc), duration_ms=duration_ms)
+        except ValueError as exc:
+            duration_ms = (time.perf_counter() - start_time) * 1000.0
+            logger.info("Complexity validation failed", extra={"error": str(exc)})
+            return evaluator_pb2.EvaluateResponse(error=str(exc), duration_ms=duration_ms)
+
+        sandbox_result = self._sandbox.run(
+            request.expression,
+            sanitized_context,
+            snapshot.symbols,
+        )
 
         if not sandbox_result.ok:
-            await context.abort(grpc.StatusCode.INVALID_ARGUMENT, sandbox_result.error or "Unknown error")
+            logger.info(
+                "Sandbox execution rejected",
+                extra={"error": sandbox_result.error, "duration_ms": sandbox_result.duration_ms},
+            )
+            return evaluator_pb2.EvaluateResponse(
+                error=sandbox_result.error or "Unknown error",
+                duration_ms=sandbox_result.duration_ms,
+            )
+
+        _log_success(metrics, sandbox_result.duration_ms)
 
         return evaluator_pb2.EvaluateResponse(
             value=sandbox_result.value,
@@ -55,8 +108,24 @@ class EvaluatorService(evaluator_pb2_grpc.EvaluatorServicer):
         )
 
 
-def _sanitize_context(context: Dict[str, str]) -> Dict[str, float]:
+def _sanitize_context(context: Dict[str, str], reserved: set[str]) -> Dict[str, float]:
     sanitized: Dict[str, float] = {}
     for key, value in context.items():
+        if not key.isidentifier():
+            raise ValueError(f"Context key {key!r} is not a valid identifier")
+        if key in reserved:
+            raise ValueError(f"Context key {key!r} collides with a reserved name")
         sanitized[key] = float(value)
     return sanitized
+
+
+def _log_success(metrics: ComplexityMetrics, duration_ms: float) -> None:
+    logger.info(
+        "Evaluated expression",
+        extra={
+            "duration_ms": duration_ms,
+            "ast_depth": metrics.depth,
+            "ast_nodes": metrics.nodes,
+            "ast_score": metrics.score,
+        },
+    )

--- a/services/safe_evaluator/pyproject.toml
+++ b/services/safe_evaluator/pyproject.toml
@@ -1,31 +1,28 @@
 [build-system]
-requires = ["setuptools>=68", "wheel"]
-build-backend = "setuptools.build_meta"
+requires = ["poetry-core>=1.9.0"]
+build-backend = "poetry.core.masonry.api"
 
-[project]
+[tool.poetry]
 name = "calculator-safe-evaluator"
 version = "0.1.0"
 description = "Sandboxed evaluator microservice"
+authors = ["Calculator Platform Team"]
 readme = "README.md"
-requires-python = ">=3.10"
-authors = [{name = "Calculator Platform Team"}]
-classifiers = [
-  "Programming Language :: Python :: 3",
-  "Topic :: Scientific/Engineering :: Mathematics",
-]
-dependencies = [
-  "pydantic-settings>=2.4.0",
-  "opentelemetry-api>=1.25.0",
-  "opentelemetry-sdk>=1.25.0",
-  "opentelemetry-instrumentation-grpc>=0.46b0",
-  "python-json-logger>=2.0.7",
-  "asteval>=1.0.6",
-  {path = "../../libs/calculator_core", develop = true},
-  {path = "../../libs/calculator_logic", develop = true},
-]
+packages = [{ include = "app" }]
 
-[project.optional-dependencies]
-dev = ["pytest", "pytest-asyncio"]
+[tool.poetry.dependencies]
+python = "^3.10"
+pydantic-settings = "^2.4.0"
+opentelemetry-api = "^1.25.0"
+opentelemetry-sdk = "^1.25.0"
+opentelemetry-instrumentation-grpc = "^0.46b0"
+python-json-logger = "^2.0.7"
+asteval = "^1.0.6"
+grpcio = "^1.64.1"
+calculator-core = {path = "../../libs/calculator_core", develop = true}
+calculator-logic = {path = "../../libs/calculator_logic", develop = true}
 
-[tool.setuptools.packages.find]
-where = ["app"]
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.0.0"
+pytest-asyncio = "^0.23.0"
+ruff = "^0.6.0"

--- a/tests/test_ast_guard.py
+++ b/tests/test_ast_guard.py
@@ -1,3 +1,5 @@
+import pytest
+
 from calculator_core import ExpressionValidator, ValidationError
 
 
@@ -15,3 +17,9 @@ def test_validator_blocks_attribute_access():
         assert "Attribute access" in str(exc)
     else:
         raise AssertionError("attribute access should be blocked")
+
+
+def test_validator_rejects_unknown_identifier():
+    validator = ExpressionValidator.default()
+    with pytest.raises(ValidationError):
+        validator.validate("foo + 1", allowed_identifiers={"bar"})

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -1,15 +1,27 @@
-from calculator_core import SandboxConfig, SandboxRunner
+import math
+
+from calculator_core import SandboxConfig, SandboxRunner, default_allowlist, filter_allowlist
 
 
 def test_sandbox_evaluates_expression():
     runner = SandboxRunner(SandboxConfig(max_runtime_seconds=1.0))
-    result = runner.run("add(1, 2) + sqrt(16)", {"addend": 0})
+    allowlist = default_allowlist()
+    result = runner.run("add(1, 2) + sqrt(16)", {}, allowlist)
     assert result.ok
-    assert abs(result.value - 7.0) < 1e-6
+    assert math.isclose(result.value, 7.0)
 
 
 def test_sandbox_validates_context_identifiers():
     runner = SandboxRunner(SandboxConfig(max_runtime_seconds=1.0))
-    result = runner.run("divide(10, value)", {"invalid key": 2})
+    allowlist = default_allowlist()
+    result = runner.run("divide(10, value)", {"invalid key": 2}, allowlist)
     assert not result.ok
     assert "valid identifier" in (result.error or "")
+
+
+def test_sandbox_respects_allowlist():
+    runner = SandboxRunner(SandboxConfig(max_runtime_seconds=1.0))
+    limited_allowlist = filter_allowlist(["add"])
+    result = runner.run("sqrt(9)", {}, limited_allowlist)
+    assert not result.ok
+    assert "not defined" in (result.error or "")


### PR DESCRIPTION
## Summary
- add calculator_core allowlist helpers, enhanced AST validation, and spawn-based sandbox resource guards
- implement evaluator-side allowlist manager with hot reload, complexity scoring, and structured logging over gRPC
- provide a default allowlist configuration and extend tests for sandbox and validator safeguards

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e087f0e5b0832db3a554a116a255ec