### PR TITLE
Implement gateway service routing, auth, and quotas

### DIFF
--- a/services/gateway/app/config.py
+++ b/services/gateway/app/config.py
@@ -36,6 +36,11 @@ class ObservabilitySettings(BaseModel):
     metrics_namespace: str = "calculator_gateway"
 
 
+class QuotaSettings(BaseModel):
+    limit: int = 1000
+    window_seconds: int = 60
+
+
 class GatewaySettings(BaseSettings):
     model_config = SettingsConfigDict(
         env_prefix="GATEWAY_",
@@ -50,6 +55,7 @@ class GatewaySettings(BaseSettings):
     database: DatabaseSettings = DatabaseSettings()
     evaluator: EvaluatorSettings = EvaluatorSettings()
     observability: ObservabilitySettings = ObservabilitySettings()
+    quota: QuotaSettings = QuotaSettings()
     audit_batch_size: int = 100
     cache_pure_results: bool = True
     allowed_origins: list[str] = ["*"]

--- a/services/gateway/app/main.py
+++ b/services/gateway/app/main.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any
+import time
 
 import grpc
 from fastapi import Depends, FastAPI, HTTPException, Request, status
@@ -19,9 +19,10 @@ from .config import get_settings
 from .database import get_session, init_db
 from .instrumentation import configure_tracing, instrument_app
 from .models import RequestAudit
+from .quota import QuotaConfig, QuotaExceededError, consume_quota
 from .rate_limit import RateLimiter
 from .schemas import CalculationResponse, ExpressionRequest
-from .security import get_api_key
+from .security import AuthenticatedAPIKey, get_api_key
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +49,10 @@ async def startup_event() -> None:
         settings.redis.rate_limit_window_seconds,
         "rate:ip",
     )
+    app.state.quota_config = QuotaConfig(
+        limit=settings.quota.limit,
+        window_seconds=settings.quota.window_seconds,
+    )
     await init_db(settings)
     app.state.grpc_channel = grpc.aio.insecure_channel(f"{settings.evaluator.host}:{settings.evaluator.port}")
     app.state.grpc_stub = evaluator_pb2_grpc.EvaluatorStub(app.state.grpc_channel)
@@ -64,7 +69,7 @@ async def shutdown_event() -> None:
 async def require_api_key(
     request: Request,
     session: AsyncSession = Depends(get_session),
-) -> Any:
+) -> AuthenticatedAPIKey:
     raw_key = request.headers.get("X-Api-Key")
     if not raw_key:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing API key")
@@ -78,21 +83,55 @@ async def require_api_key(
 async def calculate_sync(
     payload: ExpressionRequest,
     request: Request,
-    api_key=Depends(require_api_key),
+    api_key: AuthenticatedAPIKey = Depends(require_api_key),
+    session: AsyncSession = Depends(get_session),
 ) -> CalculationResponse:
     client_ip = request.client.host if request.client else "unknown"
+    api_key_id = api_key.record.id
     rate_limiter_key: RateLimiter = app.state.rate_limit_key
     rate_limiter_ip: RateLimiter = app.state.rate_limit_ip
-    if not await rate_limiter_key.allow(str(api_key.id)):
+    expression_hash = payload.hash(api_key.raw_key)
+
+    if not await rate_limiter_key.allow(str(api_key_id)):
+        await _persist_audit(
+            api_key_id,
+            expression_hash,
+            payload.expression,
+            client_ip,
+            "rate_limit_key",
+            0.0,
+        )
         raise HTTPException(status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail="API key rate limit exceeded")
     if not await rate_limiter_ip.allow(client_ip):
+        await _persist_audit(
+            api_key_id,
+            expression_hash,
+            payload.expression,
+            client_ip,
+            "rate_limit_ip",
+            0.0,
+        )
         raise HTTPException(status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail="IP rate limit exceeded")
 
+    try:
+        await consume_quota(session, api_key_id, app.state.quota_config)
+    except QuotaExceededError as exc:
+        await _persist_audit(
+            api_key_id,
+            expression_hash,
+            payload.expression,
+            client_ip,
+            "quota_exceeded",
+            0.0,
+        )
+        raise HTTPException(status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail=str(exc)) from exc
+
     cache: ResultCache = app.state.cache
-    cache_key = payload.hash(str(api_key.id))
-    cached_value = await cache.get(cache_key) if settings.cache_pure_results else None
+    cache_key = expression_hash
+    should_use_cache = settings.cache_pure_results and payload.is_pure_arithmetic()
+    cached_value = await cache.get(cache_key) if should_use_cache else None
     if cached_value is not None:
-        await _persist_audit(api_key.id, cache_key, payload.expression, client_ip, "cache", 0.0)
+        await _persist_audit(api_key_id, cache_key, payload.expression, client_ip, "cache_hit", 0.0)
         return CalculationResponse(
             expression=payload.expression,
             value=cached_value,
@@ -101,47 +140,109 @@ async def calculate_sync(
         )
 
     stub: evaluator_pb2_grpc.EvaluatorStub = app.state.grpc_stub
-    request_message = evaluator_pb2.EvaluateRequest(expression=payload.expression, context={k: str(v) for k, v in payload.context.items()})
+    request_message = evaluator_pb2.EvaluateRequest(
+        expression=payload.expression,
+        context={k: str(v) for k, v in payload.context.items()},
+    )
 
+    start_time = time.perf_counter()
     try:
         response = await stub.Evaluate(
             request_message,
             timeout=settings.evaluator.deadline_ms / 1000,
         )
     except grpc.AioRpcError as exc:
-        logger.exception("Evaluator call failed")
+        elapsed_ms = (time.perf_counter() - start_time) * 1000
         status_code = exc.code()
+        detail = exc.details() or "Evaluator unavailable"
         if status_code == grpc.StatusCode.INVALID_ARGUMENT:
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=exc.details())
+            await _persist_audit(
+                api_key_id,
+                expression_hash,
+                payload.expression,
+                client_ip,
+                "invalid_expression",
+                elapsed_ms,
+            )
+            return CalculationResponse(
+                expression=payload.expression,
+                error=detail,
+                duration_ms=elapsed_ms,
+                from_cache=False,
+            )
         if status_code == grpc.StatusCode.RESOURCE_EXHAUSTED:
-            raise HTTPException(status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail="Evaluator busy")
-        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Evaluator unavailable")
+            await _persist_audit(
+                api_key_id,
+                expression_hash,
+                payload.expression,
+                client_ip,
+                "evaluator_rate_limited",
+                elapsed_ms,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                detail="Evaluator busy",
+            ) from exc
+        logger.exception("Evaluator call failed")
+        await _persist_audit(
+            api_key_id,
+            expression_hash,
+            payload.expression,
+            client_ip,
+            "evaluator_error",
+            elapsed_ms,
+        )
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Evaluator unavailable") from exc
+
+    duration_ms = response.duration_ms or (time.perf_counter() - start_time) * 1000
+    result_type = response.WhichOneof("result")
+
+    if result_type == "error":
+        await _persist_audit(
+            api_key_id,
+            expression_hash,
+            payload.expression,
+            client_ip,
+            "evaluation_error",
+            duration_ms,
+        )
+        return CalculationResponse(
+            expression=payload.expression,
+            error=response.error,
+            duration_ms=duration_ms,
+            from_cache=False,
+        )
+
+    if should_use_cache:
+        await cache.set(cache_key, response.value)
 
     asyncio.create_task(
         _persist_audit(
-            api_key.id,
+            api_key_id,
             cache_key,
             payload.expression,
             client_ip,
             "success",
-            response.duration_ms,
+            duration_ms,
         )
     )
-
-    if settings.cache_pure_results:
-        await cache.set(cache_key, response.value)
 
     return CalculationResponse(
         expression=payload.expression,
         value=response.value,
-        duration_ms=response.duration_ms,
+        duration_ms=duration_ms,
         from_cache=False,
     )
 
 
 @app.post("/calculate", response_model=CalculationResponse)
-async def calculate(payload: ExpressionRequest, request: Request, api_key=Depends(require_api_key)) -> CalculationResponse:
-    return await calculate_sync(payload, request, api_key)
+async def calculate(
+    payload: ExpressionRequest,
+    request: Request,
+    api_key: AuthenticatedAPIKey = Depends(require_api_key),
+    session: AsyncSession = Depends(get_session),
+) -> CalculationResponse:
+    return await calculate_sync(payload, request, api_key=api_key, session=session)
 
 
 @app.get("/health/live")

--- a/services/gateway/app/quota.py
+++ b/services/gateway/app/quota.py
@@ -1,0 +1,65 @@
+"""Quota enforcement helpers."""
+
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .models import Quota
+
+
+class QuotaExceededError(RuntimeError):
+    """Raised when an API key exceeds its allotted quota."""
+
+
+@dataclass
+class QuotaConfig:
+    limit: int
+    window_seconds: int
+
+
+async def consume_quota(session: AsyncSession, api_key_id: int, config: QuotaConfig) -> None:
+    """Consume a quota unit for the API key if possible."""
+
+    if config.limit <= 0:
+        return
+
+    now = dt.datetime.utcnow()
+    window_seconds = max(config.window_seconds, 1)
+
+    async with session.begin():
+        stmt = (
+            select(Quota)
+            .where(
+                Quota.api_key_id == api_key_id,
+                Quota.window_start <= now,
+                Quota.window_end > now,
+            )
+            .with_for_update()
+        )
+        result = await session.execute(stmt)
+        quota = result.scalars().first()
+
+        if quota is None or quota.window_end <= now:
+            if quota is None:
+                quota = Quota(
+                    api_key_id=api_key_id,
+                    window_start=now,
+                    window_end=now + dt.timedelta(seconds=window_seconds),
+                    usage=0,
+                    limit=config.limit,
+                )
+                session.add(quota)
+            else:
+                quota.window_start = now
+                quota.window_end = now + dt.timedelta(seconds=window_seconds)
+                quota.usage = 0
+                quota.limit = config.limit
+
+        if quota.limit > 0 and quota.usage >= quota.limit:
+            raise QuotaExceededError("Quota exceeded for API key")
+
+        quota.usage += 1

--- a/services/gateway/app/rate_limit.py
+++ b/services/gateway/app/rate_limit.py
@@ -3,11 +3,31 @@
 from __future__ import annotations
 
 import time
+from typing import Final
 
 from redis.asyncio import Redis
 
 
 class RateLimiter:
+    """Sliding window rate limiter backed by Redis sorted sets."""
+
+    _LUA_SCRIPT: Final[str] = """
+        local key = KEYS[1]
+        local now = tonumber(ARGV[1])
+        local window = tonumber(ARGV[2])
+        local limit = tonumber(ARGV[3])
+
+        redis.call('ZREMRANGEBYSCORE', key, '-inf', now - window)
+        local current = redis.call('ZCARD', key)
+        if current >= limit then
+            return 0
+        end
+
+        redis.call('ZADD', key, now, now)
+        redis.call('PEXPIRE', key, window)
+        return 1
+    """
+
     def __init__(self, redis: Redis, limit: int, window_seconds: int, namespace: str) -> None:
         self._redis = redis
         self._limit = limit
@@ -15,9 +35,16 @@ class RateLimiter:
         self._namespace = namespace
 
     async def allow(self, key: str) -> bool:
-        now = int(time.time())
-        window_key = f"{self._namespace}:{key}:{now // self._window}"
-        count = await self._redis.incr(window_key)
-        if count == 1:
-            await self._redis.expire(window_key, self._window)
-        return count <= self._limit
+        if self._limit <= 0:
+            return True
+        now_ms = int(time.time() * 1000)
+        redis_key = f"{self._namespace}:{key}"
+        result = await self._redis.eval(
+            self._LUA_SCRIPT,
+            1,
+            redis_key,
+            now_ms,
+            self._window * 1000,
+            self._limit,
+        )
+        return bool(result)

--- a/services/gateway/app/schemas.py
+++ b/services/gateway/app/schemas.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 import hashlib
+import re
 from typing import Dict, Optional
 
 from pydantic import BaseModel, Field
+
+
+PURE_ARITHMETIC_RE = re.compile(r"^[0-9+\-*/().\s]+$")
 
 
 class ExpressionRequest(BaseModel):
@@ -17,6 +21,13 @@ class ExpressionRequest(BaseModel):
         digest.update(self.expression.encode("utf-8"))
         digest.update(api_key.encode("utf-8"))
         return digest.hexdigest()
+
+    def is_pure_arithmetic(self) -> bool:
+        """Return True when the expression can be cached safely."""
+
+        if self.context:
+            return False
+        return bool(PURE_ARITHMETIC_RE.fullmatch(self.expression.strip()))
 
 
 class CalculationResponse(BaseModel):

--- a/services/gateway/app/security.py
+++ b/services/gateway/app/security.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import datetime as dt
 import hashlib
+from dataclasses import dataclass
 from typing import Optional
 
 from sqlalchemy import select
@@ -12,13 +13,21 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from .models import APIKey
 
 
+@dataclass(frozen=True)
+class AuthenticatedAPIKey:
+    """Wrapper containing the persisted record and the raw presented key."""
+
+    record: APIKey
+    raw_key: str
+
+
 def hash_api_key(raw_key: str) -> str:
     digest = hashlib.sha256()
     digest.update(raw_key.encode("utf-8"))
     return digest.hexdigest()
 
 
-async def get_api_key(session: AsyncSession, raw_key: str) -> Optional[APIKey]:
+async def get_api_key(session: AsyncSession, raw_key: str) -> Optional[AuthenticatedAPIKey]:
     key_hash = hash_api_key(raw_key)
     stmt = select(APIKey).where(APIKey.key_hash == key_hash)
     result = await session.execute(stmt)
@@ -29,4 +38,4 @@ async def get_api_key(session: AsyncSession, raw_key: str) -> Optional[APIKey]:
         return None
     if api_key.expires_at and api_key.expires_at < dt.datetime.utcnow():
         return None
-    return api_key
+    return AuthenticatedAPIKey(record=api_key, raw_key=raw_key)


### PR DESCRIPTION
## Summary
- add gateway configuration for quotas and instantiate cache, rate limiting, and gRPC clients at startup
- implement calculation endpoints with API key authentication, Redis-backed rate limiting, quota checks, caching, and gRPC error translation
- add reusable quota enforcement helper, sliding window Redis limiter, and API key helper updates

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0a4fca12c832db019deae69650437