### PR TITLE
feat(gateway): configure datastore schema and seeding

### DIFF
--- a/services/gateway/README.md
+++ b/services/gateway/README.md
@@ -1,3 +1,41 @@
 # Calculator Gateway Service
 
 FastAPI-based entrypoint that authenticates requests, enforces quotas, and forwards calculations to the safe evaluator microservice.
+
+## Database migrations
+
+The gateway uses Alembic to manage its PostgreSQL schema. Run migrations with:
+
+```bash
+poetry run alembic upgrade head
+```
+
+The initial migration provisions the `api_keys`, `request_audit`, and `quotas` tables along with supporting indexes and foreign-key constraints.
+
+## Seed a default API key
+
+For local development you can bootstrap a default API key by executing:
+
+```bash
+poetry run python -m app.scripts.seed_api_key
+```
+
+Override the defaults using command-line flags or environment variables:
+
+```bash
+poetry run python -m app.scripts.seed_api_key --api-key=my-key --owner="QA" --scopes="calculate,inspect"
+```
+
+Environment variables `GATEWAY_SEED_API_KEY`, `GATEWAY_SEED_API_KEY_OWNER`, and `GATEWAY_SEED_API_KEY_SCOPES` provide the same overrides. Pass `--force` to update an existing record while keeping the raw key the same.
+
+## Redis namespaces and TTLs
+
+Redis keys follow the pattern:
+
+| Purpose | Key pattern | Default TTL |
+| --- | --- | --- |
+| API key rate limiting | `rate:{api_key_id}` | 60 seconds |
+| IP limiter | `limiter:{ip}` | 60 seconds |
+| Calculation result cache | `cache:{expression_hash}` | 5 minutes |
+
+All TTL values are configurable through `GatewaySettings.redis` in `app/config.py`.

--- a/services/gateway/alembic/env.py
+++ b/services/gateway/alembic/env.py
@@ -4,12 +4,10 @@ from __future__ import annotations
 
 import asyncio
 from logging.config import fileConfig
-from pathlib import Path
 
 from alembic import context
 from sqlalchemy import pool
-from sqlalchemy.engine import Connection
-from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+from sqlalchemy.ext.asyncio import create_async_engine
 
 from app.config import get_settings
 from app.models import Base

--- a/services/gateway/alembic/versions/20250101000000_initial_tables.py
+++ b/services/gateway/alembic/versions/20250101000000_initial_tables.py
@@ -25,7 +25,12 @@ def upgrade() -> None:
     op.create_table(
         "request_audit",
         sa.Column("id", sa.Integer(), primary_key=True),
-        sa.Column("api_key_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "api_key_id",
+            sa.Integer(),
+            sa.ForeignKey("api_keys.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
         sa.Column("expression_hash", sa.String(length=128), nullable=False),
         sa.Column("expression", sa.String(length=512), nullable=False),
         sa.Column("client_ip", sa.String(length=64), nullable=False),
@@ -36,15 +41,38 @@ def upgrade() -> None:
     op.create_table(
         "quotas",
         sa.Column("id", sa.Integer(), primary_key=True),
-        sa.Column("api_key_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "api_key_id",
+            sa.Integer(),
+            sa.ForeignKey("api_keys.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
         sa.Column("window_start", sa.DateTime(timezone=True), nullable=False),
         sa.Column("window_end", sa.DateTime(timezone=True), nullable=False),
         sa.Column("usage", sa.Integer(), nullable=False, server_default="0"),
         sa.Column("limit", sa.Integer(), nullable=False, server_default="0"),
     )
+    op.create_index(
+        "ix_request_audit_api_key_id_created_at",
+        "request_audit",
+        ["api_key_id", "created_at"],
+    )
+    op.create_index(
+        "ix_request_audit_expression_hash",
+        "request_audit",
+        ["expression_hash"],
+    )
+    op.create_index(
+        "ix_quotas_api_key_window",
+        "quotas",
+        ["api_key_id", "window_start"],
+    )
 
 
 def downgrade() -> None:
+    op.drop_index("ix_quotas_api_key_window", table_name="quotas")
+    op.drop_index("ix_request_audit_expression_hash", table_name="request_audit")
+    op.drop_index("ix_request_audit_api_key_id_created_at", table_name="request_audit")
     op.drop_table("quotas")
     op.drop_table("request_audit")
     op.drop_table("api_keys")

--- a/services/gateway/app/config.py
+++ b/services/gateway/app/config.py
@@ -14,8 +14,9 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class RedisSettings(BaseModel):
     url: str = "redis://localhost:6379/0"
     cache_ttl_seconds: int = 300
-    rate_limit_window_seconds: int = 1
+    rate_limit_window_seconds: int = 60
     rate_limit_requests: int = 10
+    rate_counter_ttl_seconds: int = 60
 
 
 class DatabaseSettings(BaseModel):

--- a/services/gateway/app/database.py
+++ b/services/gateway/app/database.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import AsyncGenerator
+from pathlib import Path
 
+from alembic import command
+from alembic.config import Config as AlembicConfig
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
 
 from .config import GatewaySettings, get_settings
-from .models import Base
 
 _engine: AsyncEngine | None = None
 _Session: async_sessionmaker[AsyncSession] | None = None
@@ -31,6 +34,16 @@ async def get_session() -> AsyncGenerator[AsyncSession, None]:
 
 
 async def init_db(settings: GatewaySettings | None = None) -> None:
-    engine = await get_engine(settings)
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
+    settings = settings or get_settings()
+    alembic_config = AlembicConfig(str(_alembic_ini_path()))
+    alembic_config.set_main_option("sqlalchemy.url", settings.database.url)
+    alembic_config.set_main_option("script_location", str(_alembic_script_path()))
+    await asyncio.to_thread(command.upgrade, alembic_config, "head")
+
+
+def _alembic_ini_path() -> Path:
+    return Path(__file__).resolve().parent.parent / "alembic.ini"
+
+
+def _alembic_script_path() -> Path:
+    return Path(__file__).resolve().parent.parent / "alembic"

--- a/services/gateway/app/instrumentation.py
+++ b/services/gateway/app/instrumentation.py
@@ -7,7 +7,7 @@ from collections import deque
 import logging
 import time
 import uuid
-from typing import Any, Awaitable, Callable
+from typing import Awaitable, Callable
 
 from fastapi import FastAPI
 from opentelemetry import trace

--- a/services/gateway/app/main.py
+++ b/services/gateway/app/main.py
@@ -48,17 +48,20 @@ async def startup_event() -> None:
     app.state.settings = settings
     app.state.redis = Redis.from_url(settings.redis.url, decode_responses=True)
     app.state.cache = ResultCache(app.state.redis, settings.redis.cache_ttl_seconds)
+    rate_counter_ttl = settings.redis.rate_counter_ttl_seconds
     app.state.rate_limit_key = RateLimiter(
         app.state.redis,
         settings.redis.rate_limit_requests,
         settings.redis.rate_limit_window_seconds,
-        "rate:key",
+        "rate",
+        ttl_seconds=rate_counter_ttl,
     )
     app.state.rate_limit_ip = RateLimiter(
         app.state.redis,
         settings.redis.rate_limit_requests * 2,
         settings.redis.rate_limit_window_seconds,
-        "rate:ip",
+        "limiter",
+        ttl_seconds=rate_counter_ttl,
     )
     app.state.quota_config = QuotaConfig(
         limit=settings.quota.limit,

--- a/services/gateway/app/models.py
+++ b/services/gateway/app/models.py
@@ -1,13 +1,11 @@
 """SQLAlchemy models for the gateway service."""
 
-"""Database models for the gateway service."""
-
 from __future__ import annotations
 
 import datetime as dt
 from typing import Optional
 
-from sqlalchemy import Boolean, DateTime, Float, Integer, String
+from sqlalchemy import Boolean, DateTime, Float, ForeignKey, Index, Integer, String
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 
@@ -29,9 +27,17 @@ class APIKey(Base):
 
 class RequestAudit(Base):
     __tablename__ = "request_audit"
+    __table_args__ = (
+        Index("ix_request_audit_api_key_id_created_at", "api_key_id", "created_at"),
+        Index("ix_request_audit_expression_hash", "expression_hash"),
+    )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    api_key_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    api_key_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("api_keys.id", ondelete="CASCADE"),
+        nullable=False,
+    )
     expression_hash: Mapped[str] = mapped_column(String(128), nullable=False)
     expression: Mapped[str] = mapped_column(String(512), nullable=False)
     client_ip: Mapped[str] = mapped_column(String(64), nullable=False)
@@ -42,9 +48,16 @@ class RequestAudit(Base):
 
 class Quota(Base):
     __tablename__ = "quotas"
+    __table_args__ = (
+        Index("ix_quotas_api_key_window", "api_key_id", "window_start"),
+    )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    api_key_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    api_key_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("api_keys.id", ondelete="CASCADE"),
+        nullable=False,
+    )
     window_start: Mapped[dt.datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     window_end: Mapped[dt.datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     usage: Mapped[int] = mapped_column(Integer, default=0)

--- a/services/gateway/app/rate_limit.py
+++ b/services/gateway/app/rate_limit.py
@@ -16,6 +16,7 @@ class RateLimiter:
         local now = tonumber(ARGV[1])
         local window = tonumber(ARGV[2])
         local limit = tonumber(ARGV[3])
+        local ttl = tonumber(ARGV[4])
 
         redis.call('ZREMRANGEBYSCORE', key, '-inf', now - window)
         local current = redis.call('ZCARD', key)
@@ -24,15 +25,25 @@ class RateLimiter:
         end
 
         redis.call('ZADD', key, now, now)
-        redis.call('PEXPIRE', key, window)
+        if ttl > 0 then
+            redis.call('PEXPIRE', key, ttl)
+        end
         return 1
     """
 
-    def __init__(self, redis: Redis, limit: int, window_seconds: int, namespace: str) -> None:
+    def __init__(
+        self,
+        redis: Redis,
+        limit: int,
+        window_seconds: int,
+        namespace: str,
+        ttl_seconds: int | None = None,
+    ) -> None:
         self._redis = redis
         self._limit = limit
         self._window = window_seconds
         self._namespace = namespace
+        self._ttl = ttl_seconds if ttl_seconds is not None else window_seconds
 
     async def allow(self, key: str) -> bool:
         if self._limit <= 0:
@@ -46,5 +57,6 @@ class RateLimiter:
             now_ms,
             self._window * 1000,
             self._limit,
+            int(self._ttl * 1000),
         )
         return bool(result)

--- a/services/gateway/app/scripts/__init__.py
+++ b/services/gateway/app/scripts/__init__.py
@@ -1,0 +1,5 @@
+"""Helper scripts for the gateway service."""
+
+from __future__ import annotations
+
+__all__ = []

--- a/services/gateway/app/scripts/seed_api_key.py
+++ b/services/gateway/app/scripts/seed_api_key.py
@@ -1,0 +1,100 @@
+"""Seed a default API key for local development."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from app.config import GatewaySettings, get_settings
+from app.database import get_engine, init_db
+from app.models import APIKey
+from app.security import hash_api_key
+
+DEFAULT_API_KEY = "calculator-local-dev-key"
+DEFAULT_OWNER = "Local Development"
+DEFAULT_SCOPES = "calculate"
+
+
+async def seed_api_key(
+    settings: GatewaySettings,
+    raw_key: str,
+    owner: str,
+    scopes: str,
+    force: bool,
+) -> dict[str, str]:
+    await init_db(settings)
+    engine = await get_engine(settings)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    async with session_factory() as session:
+        key_hash = hash_api_key(raw_key)
+        result = await session.execute(select(APIKey).where(APIKey.key_hash == key_hash))
+        record = result.scalars().first()
+
+        if record:
+            if force:
+                record.owner = owner
+                record.scopes = scopes
+                record.active = True
+                record.expires_at = None
+                await session.commit()
+                status = "updated"
+            else:
+                status = "unchanged"
+            return {"status": status, "owner": record.owner, "scopes": record.scopes}
+
+        api_key = APIKey(
+            key_hash=key_hash,
+            owner=owner,
+            scopes=scopes,
+        )
+        session.add(api_key)
+        await session.commit()
+        return {"status": "created", "owner": owner, "scopes": scopes}
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Seed a default API key for the gateway service")
+    parser.add_argument(
+        "--api-key",
+        default=os.getenv("GATEWAY_SEED_API_KEY", DEFAULT_API_KEY),
+        help="Raw API key value to persist (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--owner",
+        default=os.getenv("GATEWAY_SEED_API_KEY_OWNER", DEFAULT_OWNER),
+        help="Owner label for the API key (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--scopes",
+        default=os.getenv("GATEWAY_SEED_API_KEY_SCOPES", DEFAULT_SCOPES),
+        help="Scopes to associate with the API key (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Update the existing API key if it already exists",
+    )
+    return parser.parse_args()
+
+
+async def _async_main() -> None:
+    args = _parse_args()
+    settings = get_settings()
+    result = await seed_api_key(settings, args.api_key, args.owner, args.scopes, args.force)
+    print(
+        "API key %s for owner '%s' with scopes '%s'. Raw key: %s"
+        % (result["status"], result["owner"], result["scopes"], args.api_key)
+    )
+
+
+def main() -> None:
+    asyncio.run(_async_main())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add foreign keys and supporting indexes for the gateway's api_keys, request_audit, and quotas tables via alembic and ORM models
- ensure the service applies alembic migrations at startup and expose Redis TTL defaults for rate limiting namespaces
- document datastore workflows and add a CLI to seed a default development API key

## Testing
- poetry run ruff check

------
https://chatgpt.com/codex/tasks/task_e_68e0aac49458832dae6ce65573edd314