### PR TITLE
Add configurable Redis namespaces and TTL handling

### DIFF
--- a/services/gateway/README.md
+++ b/services/gateway/README.md
@@ -34,8 +34,8 @@ Redis keys follow the pattern:
 
 | Purpose | Key pattern | Default TTL |
 | --- | --- | --- |
-| API key rate limiting | `rate:{api_key_id}` | 60 seconds |
-| IP limiter | `limiter:{ip}` | 60 seconds |
-| Calculation result cache | `cache:{expression_hash}` | 5 minutes |
+| API key rate limiting | `{settings.redis.rate_namespace}:{api_key_id}` | 60 seconds |
+| IP limiter | `{settings.redis.limiter_namespace}:{ip}` | 60 seconds |
+| Calculation result cache | `{settings.redis.cache_namespace}:{expression_hash}` | 5 minutes |
 
-All TTL values are configurable through `GatewaySettings.redis` in `app/config.py`.
+Namespaces and TTL values are configurable through `GatewaySettings.redis` in `app/config.py`.

--- a/services/gateway/app/cache.py
+++ b/services/gateway/app/cache.py
@@ -9,12 +9,13 @@ from redis.asyncio import Redis
 
 
 class ResultCache:
-    def __init__(self, redis: Redis, ttl_seconds: int) -> None:
+    def __init__(self, redis: Redis, ttl_seconds: int, namespace: str = "cache") -> None:
         self._redis = redis
         self._ttl = ttl_seconds
+        self._namespace = namespace
 
     async def get(self, key: str) -> Optional[float]:
-        raw = await self._redis.get(f"cache:{key}")
+        raw = await self._redis.get(self._format_key(key))
         if raw is None:
             return None
         try:
@@ -25,4 +26,11 @@ class ResultCache:
 
     async def set(self, key: str, value: float) -> None:
         payload = json.dumps({"value": value})
-        await self._redis.set(f"cache:{key}", payload, ex=self._ttl)
+        redis_key = self._format_key(key)
+        if self._ttl > 0:
+            await self._redis.set(redis_key, payload, ex=self._ttl)
+        else:
+            await self._redis.set(redis_key, payload)
+
+    def _format_key(self, key: str) -> str:
+        return f"{self._namespace}:{key}"

--- a/services/gateway/app/config.py
+++ b/services/gateway/app/config.py
@@ -14,9 +14,12 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class RedisSettings(BaseModel):
     url: str = "redis://localhost:6379/0"
     cache_ttl_seconds: int = 300
+    cache_namespace: str = "cache"
     rate_limit_window_seconds: int = 60
     rate_limit_requests: int = 10
     rate_counter_ttl_seconds: int = 60
+    rate_namespace: str = "rate"
+    limiter_namespace: str = "limiter"
 
 
 class DatabaseSettings(BaseModel):

--- a/services/gateway/app/main.py
+++ b/services/gateway/app/main.py
@@ -47,20 +47,24 @@ tracer = trace.get_tracer(__name__)
 async def startup_event() -> None:
     app.state.settings = settings
     app.state.redis = Redis.from_url(settings.redis.url, decode_responses=True)
-    app.state.cache = ResultCache(app.state.redis, settings.redis.cache_ttl_seconds)
+    app.state.cache = ResultCache(
+        app.state.redis,
+        settings.redis.cache_ttl_seconds,
+        namespace=settings.redis.cache_namespace,
+    )
     rate_counter_ttl = settings.redis.rate_counter_ttl_seconds
     app.state.rate_limit_key = RateLimiter(
         app.state.redis,
         settings.redis.rate_limit_requests,
         settings.redis.rate_limit_window_seconds,
-        "rate",
+        settings.redis.rate_namespace,
         ttl_seconds=rate_counter_ttl,
     )
     app.state.rate_limit_ip = RateLimiter(
         app.state.redis,
         settings.redis.rate_limit_requests * 2,
         settings.redis.rate_limit_window_seconds,
-        "limiter",
+        settings.redis.limiter_namespace,
         ttl_seconds=rate_counter_ttl,
     )
     app.state.quota_config = QuotaConfig(

--- a/services/gateway/app/rate_limit.py
+++ b/services/gateway/app/rate_limit.py
@@ -50,6 +50,7 @@ class RateLimiter:
             return True
         now_ms = int(time.time() * 1000)
         redis_key = f"{self._namespace}:{key}"
+        ttl_ms = max(int(self._ttl * 1000), 0)
         result = await self._redis.eval(
             self._LUA_SCRIPT,
             1,
@@ -57,6 +58,6 @@ class RateLimiter:
             now_ms,
             self._window * 1000,
             self._limit,
-            int(self._ttl * 1000),
+            ttl_ms,
         )
         return bool(result)


### PR DESCRIPTION
## Summary
- extend Redis settings to expose cache, rate, and limiter namespaces alongside TTL defaults
- update rate limiting and result cache helpers to respect the configured namespaces and handle non-positive TTLs gracefully
- document the configurable Redis key patterns for developers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0ac8d1c00832d95c304d12bca5028