### PR TITLE
Enhance local gRPC shim and gateway channel creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,23 +4,23 @@ POETRY ?= poetry
 .PHONY: bootstrap lint test run-gateway run-evaluator compose-up compose-down
 
 bootstrap:
-$(POETRY) -C services/gateway install
-$(POETRY) -C services/safe_evaluator install
+	$(POETRY) -C services/gateway install
+	$(POETRY) -C services/safe_evaluator install
 
 lint:
-$(POETRY) -C services/gateway run ruff check app ../safe_evaluator/app ../../libs
+	$(POETRY) -C services/gateway run ruff check app ../safe_evaluator/app ../../libs
 
 test:
-$(POETRY) -C services/safe_evaluator run pytest ../../tests
+	$(POETRY) -C services/safe_evaluator run pytest ../../tests
 
 run-gateway:
-$(POETRY) -C services/gateway run uvicorn app.main:app --host 0.0.0.0 --port 8080 --reload
+	$(POETRY) -C services/gateway run uvicorn app.main:app --host 0.0.0.0 --port 8080 --reload
 
 run-evaluator:
-$(POETRY) -C services/safe_evaluator run python -m app.server
+	$(POETRY) -C services/safe_evaluator run python -m app.server
 
 compose-up:
-docker compose -f docker-compose.phase1.yml up --build
+	docker compose -f docker-compose.phase1.yml up --build
 
 compose-down:
-docker compose -f docker-compose.phase1.yml down
+	docker compose -f docker-compose.phase1.yml down

--- a/grpc/__init__.py
+++ b/grpc/__init__.py
@@ -1,28 +1,43 @@
-"""Minimal asynchronous RPC layer used for offline gRPC development."""
+"""Lightweight asyncio-compatible gRPC shims for the kata environment."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Awaitable, Callable, Dict
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Sequence, Tuple
 
 
 class StatusCode(Enum):
     OK = 0
+    CANCELLED = 1
+    UNKNOWN = 2
     INVALID_ARGUMENT = 3
     DEADLINE_EXCEEDED = 4
     NOT_FOUND = 5
+    ALREADY_EXISTS = 6
     PERMISSION_DENIED = 7
     RESOURCE_EXHAUSTED = 8
+    FAILED_PRECONDITION = 9
+    ABORTED = 10
+    OUT_OF_RANGE = 11
+    UNIMPLEMENTED = 12
     INTERNAL = 13
     UNAVAILABLE = 14
+    DATA_LOSS = 15
+    UNAUTHENTICATED = 16
 
 
 class RpcError(Exception):
-    def __init__(self, code: StatusCode, details: str = "") -> None:
+    def __init__(
+        self,
+        code: StatusCode,
+        details: str = "",
+        trailing_metadata: Optional[Sequence[Tuple[str, str]]] = None,
+    ) -> None:
+        super().__init__(details)
         self._code = code
         self._details = details
-        super().__init__(details)
+        self._trailing_metadata = list(trailing_metadata or [])
 
     def code(self) -> StatusCode:
         return self._code
@@ -30,15 +45,33 @@ class RpcError(Exception):
     def details(self) -> str:
         return self._details
 
+    def trailing_metadata(self) -> List[Tuple[str, str]]:
+        return list(self._trailing_metadata)
+
 
 class AioRpcError(RpcError):
-    pass
+    """Exception raised when an asyncio RPC fails."""
 
 
-@dataclass
-class GenericRpcHandler:
-    service_name: str
-    method_handlers: Dict[str, "UnaryUnaryRpcMethodHandler"]
+@dataclass(slots=True)
+class MetadataItem:
+    key: str
+    value: str
+
+
+@dataclass(slots=True)
+class ChannelCredentials:
+    root_certificates: Optional[bytes] = None
+    private_key: Optional[bytes] = None
+    certificate_chain: Optional[bytes] = None
+
+
+def ssl_channel_credentials(
+    root_certificates: Optional[bytes] = None,
+    private_key: Optional[bytes] = None,
+    certificate_chain: Optional[bytes] = None,
+) -> ChannelCredentials:
+    return ChannelCredentials(root_certificates, private_key, certificate_chain)
 
 
 class UnaryUnaryRpcMethodHandler:
@@ -49,24 +82,57 @@ class UnaryUnaryRpcMethodHandler:
         return await self._coroutine(request, context)
 
 
+@dataclass(slots=True)
+class GenericRpcHandler:
+    service_name: str
+    method_handlers: Dict[str, UnaryUnaryRpcMethodHandler]
+
+
 class ServicerContext:
+    def __init__(
+        self,
+        metadata: Sequence[MetadataItem] | None = None,
+        peer: str = "",
+    ) -> None:
+        self._metadata = tuple(metadata or ())
+        self._peer = peer
+        self._trailing_metadata: List[Tuple[str, str]] = []
+
+    def invocation_metadata(self) -> Tuple[MetadataItem, ...]:
+        return self._metadata
+
+    def set_trailing_metadata(self, metadata: Sequence[Tuple[str, str]]) -> None:
+        self._trailing_metadata = [(str(key), str(value)) for key, value in metadata]
+
+    def trailing_metadata(self) -> Tuple[Tuple[str, str], ...]:
+        return tuple(self._trailing_metadata)
+
+    def peer(self) -> str:
+        return self._peer
+
     async def abort(self, code: StatusCode, details: str) -> None:
-        raise AioRpcError(code, details)
+        raise AioRpcError(code, details, self._trailing_metadata)
 
 
-def method_handlers_generic_handler(service_name: str, handlers: Dict[str, UnaryUnaryRpcMethodHandler]) -> GenericRpcHandler:
+def method_handlers_generic_handler(
+    service_name: str,
+    handlers: Dict[str, UnaryUnaryRpcMethodHandler],
+) -> GenericRpcHandler:
     return GenericRpcHandler(service_name, handlers)
 
 
-from . import aio  # noqa: E402  (import at end to avoid circular import)
+from . import aio  # noqa: E402
 
 __all__ = [
-    "StatusCode",
-    "RpcError",
     "AioRpcError",
-    "ServicerContext",
-    "UnaryUnaryRpcMethodHandler",
+    "ChannelCredentials",
     "GenericRpcHandler",
-    "method_handlers_generic_handler",
+    "MetadataItem",
+    "RpcError",
+    "ServicerContext",
+    "StatusCode",
+    "UnaryUnaryRpcMethodHandler",
     "aio",
+    "method_handlers_generic_handler",
+    "ssl_channel_credentials",
 ]

--- a/grpc/aio/__init__.py
+++ b/grpc/aio/__init__.py
@@ -1,13 +1,27 @@
-"""Very small asyncio RPC transport used as a stand-in for grpc.aio."""
+"""Asyncio-friendly helpers for the lightweight gRPC shim."""
 
 from __future__ import annotations
 
 import asyncio
 import json
+from dataclasses import dataclass
+from typing import Any, Iterable, Optional, Sequence, Tuple
 
-from typing import Any, Awaitable, Callable, Dict, Optional
+from .. import (
+    AioRpcError,
+    ChannelCredentials,
+    GenericRpcHandler,
+    MetadataItem,
+    ServicerContext,
+    StatusCode,
+    UnaryUnaryRpcMethodHandler,
+)
 
-from .. import AioRpcError, GenericRpcHandler, ServicerContext, StatusCode
+
+@dataclass
+class _PendingResponse:
+    data: Any
+    trailing_metadata: Sequence[Tuple[str, str]]
 
 
 class UnaryUnaryMultiCallable:
@@ -15,21 +29,45 @@ class UnaryUnaryMultiCallable:
         self._channel = channel
         self._method = method
 
-    async def __call__(self, request: Any, timeout: Optional[float] = None, metadata: Any = None) -> Any:
-        return await self._channel._invoke(self._method, request, timeout)
+    async def __call__(
+        self,
+        request: Any,
+        timeout: Optional[float] = None,
+        metadata: Optional[Sequence[Tuple[str, str]]] = None,
+    ) -> Any:
+        pending = await self._channel._invoke(self._method, request, timeout, metadata)
+        return pending.data
 
 
 class Channel:
-    def __init__(self, host: str, port: int) -> None:
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        *,
+        credentials: ChannelCredentials | None = None,
+    ) -> None:
         self._host = host
         self._port = port
+        self._credentials = credentials
 
     def unary_unary(self, method: str) -> UnaryUnaryMultiCallable:
         return UnaryUnaryMultiCallable(self, method)
 
-    async def _invoke(self, method: str, request: Any, timeout: Optional[float]) -> Any:
+    async def _invoke(
+        self,
+        method: str,
+        request: Any,
+        timeout: Optional[float],
+        metadata: Optional[Sequence[Tuple[str, str]]],
+    ) -> _PendingResponse:
         service, rpc = _split_method(method)
-        payload = {"service": service, "method": rpc, "data": request.to_dict()}
+        payload = {
+            "service": service,
+            "method": rpc,
+            "data": request.to_dict(),
+            "metadata": [(str(k), str(v)) for k, v in (metadata or ())],
+        }
         reader, writer = await asyncio.open_connection(self._host, self._port)
         message = json.dumps(payload).encode("utf-8") + b"\n"
         writer.write(message)
@@ -45,27 +83,28 @@ class Channel:
         if not raw:
             raise AioRpcError(StatusCode.UNAVAILABLE, "No response from evaluator")
         response = json.loads(raw.decode("utf-8"))
+        trailing_metadata = [(str(k), str(v)) for k, v in response.get("trailing_metadata", [])]
         if "error" in response:
             error = response["error"]
-            raise AioRpcError(StatusCode[error.get("code", "INTERNAL")], error.get("details", ""))
-        return response["data"]
+            code_name = error.get("code", "INTERNAL")
+            details = error.get("details", "")
+            raise AioRpcError(StatusCode[code_name], details, trailing_metadata)
+        return _PendingResponse(response.get("data"), trailing_metadata)
 
-    async def close(self) -> None:
+    async def close(self) -> None:  # noqa: D401 - compatibility shim
         return None
 
 
 class Server:
     def __init__(self) -> None:
-        self._handlers: Dict[str, Dict[str, Callable[[Any, ServicerContext], Awaitable[Any]]]] = {}
-        self._server: Optional[asyncio.base_events.Server] = None
+        self._handlers: dict[str, dict[str, UnaryUnaryRpcMethodHandler]] = {}
+        self._server: Optional[asyncio.AbstractServer] = None
         self._host = "127.0.0.1"
         self._port = 0
 
     def add_generic_rpc_handlers(self, handlers: list[GenericRpcHandler]) -> None:
         for handler in handlers:
-            self._handlers[handler.service_name] = {
-                name: method.__call__ for name, method in handler.method_handlers.items()
-            }
+            self._handlers[handler.service_name] = handler.method_handlers
 
     def add_insecure_port(self, target: str) -> str:
         host, port = target.split(":")
@@ -97,33 +136,60 @@ class Server:
         service = request.get("service")
         method = request.get("method")
         data = request.get("data", {})
-        response: Dict[str, Any]
-        try:
-            handler = self._handlers[service][method]
-            context = ServicerContext()
-            result = await handler(data, context)
-        except AioRpcError as exc:
-            response = {"error": {"code": exc.code().name, "details": exc.details()}}
-        except Exception as exc:  # noqa: BLE001
-            response = {"error": {"code": StatusCode.INTERNAL.name, "details": str(exc)}}
+        metadata_pairs = [(str(k), str(v)) for k, v in request.get("metadata", [])]
+        metadata = [MetadataItem(key=k, value=v) for k, v in metadata_pairs]
+        peer_info = writer.get_extra_info("peername")
+        peer = "" if peer_info is None else f"{peer_info[0]}:{peer_info[1]}"
+        context = ServicerContext(metadata=metadata, peer=peer)
+
+        response: dict[str, Any]
+        handler = self._handlers.get(service, {}).get(method)
+        if handler is None:
+            response = {"error": {"code": StatusCode.UNIMPLEMENTED.name, "details": "Unknown RPC"}}
         else:
-            response = {"data": result}
+            try:
+                result = await handler(data, context)
+            except AioRpcError as exc:  # pragma: no cover - abort path
+                response = {
+                    "error": {"code": exc.code().name, "details": exc.details()},
+                    "trailing_metadata": exc.trailing_metadata(),
+                }
+            except Exception as exc:  # noqa: BLE001
+                response = {
+                    "error": {"code": StatusCode.INTERNAL.name, "details": str(exc)},
+                    "trailing_metadata": list(context.trailing_metadata()),
+                }
+            else:
+                response = {
+                    "data": result,
+                    "trailing_metadata": list(context.trailing_metadata()),
+                }
+
         writer.write(json.dumps(response).encode("utf-8") + b"\n")
         await writer.drain()
         writer.close()
         await writer.wait_closed()
 
 
-def insecure_channel(target: str) -> Channel:
+def insecure_channel(target: str, options: Optional[Iterable[Tuple[str, Any]]] = None) -> Channel:
     host, port = target.split(":")
     return Channel(host, int(port))
+
+
+def secure_channel(
+    target: str,
+    credentials: ChannelCredentials,
+    options: Optional[Iterable[Tuple[str, Any]]] = None,
+) -> Channel:
+    host, port = target.split(":")
+    return Channel(host, int(port), credentials=credentials)
 
 
 def server() -> Server:
     return Server()
 
 
-def _split_method(method: str) -> tuple[str, str]:
+def _split_method(method: str) -> Tuple[str, str]:
     if not method.startswith("/"):
         raise ValueError("Method must be of the form /package.Service/Method")
     _, service, rpc = method.split("/", 2)
@@ -132,8 +198,8 @@ def _split_method(method: str) -> tuple[str, str]:
 
 __all__ = [
     "Channel",
-    "Server",
     "UnaryUnaryMultiCallable",
     "insecure_channel",
+    "secure_channel",
     "server",
 ]

--- a/services/gateway/app/config.py
+++ b/services/gateway/app/config.py
@@ -32,6 +32,10 @@ class EvaluatorSettings(BaseModel):
     host: str = "safe-evaluator"
     port: int = 50051
     deadline_ms: int = 250
+    use_tls: bool = False
+    root_cert_path: Optional[Path] = None
+    client_cert_path: Optional[Path] = None
+    client_key_path: Optional[Path] = None
 
 
 class ObservabilitySettings(BaseModel):

--- a/services/gateway/app/main.py
+++ b/services/gateway/app/main.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+from pathlib import Path
+from typing import Optional
 
 import grpc
 from opentelemetry import trace
@@ -18,7 +20,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from services.protos import evaluator_pb2, evaluator_pb2_grpc
 
 from .cache import ResultCache
-from .config import get_settings
+from .config import EvaluatorSettings, get_settings
 from .database import get_session, init_db
 from .instrumentation import (
     configure_logging,
@@ -72,7 +74,7 @@ async def startup_event() -> None:
         window_seconds=settings.quota.window_seconds,
     )
     await init_db(settings)
-    app.state.grpc_channel = grpc.aio.insecure_channel(f"{settings.evaluator.host}:{settings.evaluator.port}")
+    app.state.grpc_channel = _create_grpc_channel(settings.evaluator)
     app.state.grpc_stub = evaluator_pb2_grpc.EvaluatorStub(app.state.grpc_channel)
     logger.info("Gateway started on %s:%s", settings.host, settings.port)
 
@@ -315,6 +317,27 @@ async def _persist_audit(
         session.add(audit)
         await session.commit()
         break
+
+
+def _create_grpc_channel(evaluator: EvaluatorSettings) -> grpc.aio.Channel:
+    target = f"{evaluator.host}:{evaluator.port}"
+    if evaluator.use_tls:
+        credentials = grpc.ssl_channel_credentials(
+            root_certificates=_read_optional_bytes(evaluator.root_cert_path),
+            private_key=_read_optional_bytes(evaluator.client_key_path),
+            certificate_chain=_read_optional_bytes(evaluator.client_cert_path),
+        )
+        return grpc.aio.secure_channel(target, credentials)
+    return grpc.aio.insecure_channel(target)
+
+
+def _read_optional_bytes(path: Optional[Path]) -> Optional[bytes]:
+    if path is None:
+        return None
+    resolved = Path(path).expanduser()
+    if not resolved.exists():
+        raise RuntimeError(f"gRPC credential file not found: {resolved}")
+    return resolved.read_bytes()
 
 
 def _build_grpc_metadata(request: Request) -> list[tuple[str, str]]:

--- a/services/protos/evaluator_pb2.py
+++ b/services/protos/evaluator_pb2.py
@@ -46,6 +46,17 @@ class EvaluateResponse:
             duration_ms=float(payload.get("duration_ms", 0.0)),
         )
 
+    def WhichOneof(self, group: str) -> Optional[str]:
+        """Mirror the protobuf API for gateway compatibility."""
+
+        if group != "result":
+            return None
+        if self.value is not None:
+            return "value"
+        if self.error is not None:
+            return "error"
+        return None
+
     @property
     def result(self) -> str:
         if self.value is not None:

--- a/services/protos/evaluator_pb2_grpc.py
+++ b/services/protos/evaluator_pb2_grpc.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Sequence
+
 import grpc
 
 from . import evaluator_pb2 as evaluator__pb2
@@ -11,9 +13,14 @@ class EvaluatorStub:
     def __init__(self, channel: grpc.aio.Channel) -> None:
         self._channel = channel
 
-    async def Evaluate(self, request: evaluator__pb2.EvaluateRequest, timeout: float | None = None) -> evaluator__pb2.EvaluateResponse:
+    async def Evaluate(
+        self,
+        request: evaluator__pb2.EvaluateRequest,
+        timeout: float | None = None,
+        metadata: Sequence[tuple[str, str]] | None = None,
+    ) -> evaluator__pb2.EvaluateResponse:
         callable_ = self._channel.unary_unary("/evaluator.v1.Evaluator/Evaluate")
-        response_payload = await callable_(request, timeout=timeout)
+        response_payload = await callable_(request, timeout=timeout, metadata=metadata)
         return evaluator__pb2.EvaluateResponse.from_dict(response_payload)
 
 

--- a/tests/test_evaluator_pb2.py
+++ b/tests/test_evaluator_pb2.py
@@ -1,0 +1,17 @@
+from services.protos import evaluator_pb2
+
+
+def test_evaluate_response_which_oneof_value():
+    response = evaluator_pb2.EvaluateResponse(value=2.5, duration_ms=1.0)
+    assert response.WhichOneof("result") == "value"
+
+
+def test_evaluate_response_which_oneof_error():
+    response = evaluator_pb2.EvaluateResponse(error="boom", duration_ms=1.0)
+    assert response.WhichOneof("result") == "error"
+
+
+def test_evaluate_response_which_oneof_unknown_group():
+    response = evaluator_pb2.EvaluateResponse(duration_ms=0.0)
+    assert response.WhichOneof("result") is None
+    assert response.WhichOneof("other") is None


### PR DESCRIPTION
## Summary
- extend the local grpc shim to support metadata propagation, trailing metadata, and placeholder TLS credentials for future mTLS integration
- add optional TLS configuration to the gateway evaluator client and centralize channel creation
- ensure EvaluateResponse exposes a WhichOneof helper, forward metadata through the stub, and cover the behavior with tests

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68e0b07700cc832da4ec58341bb377a1