### PR TITLE
Restore gRPC compatibility and add coverage for gateway/evaluator services

### DIFF
--- a/calculator_grpc/__init__.py
+++ b/calculator_grpc/__init__.py
@@ -66,12 +66,38 @@ class ChannelCredentials:
     certificate_chain: Optional[bytes] = None
 
 
+@dataclass(slots=True)
+class ServerCredentials:
+    private_key: bytes
+    certificate_chain: bytes
+    root_certificates: Optional[bytes] = None
+    require_client_auth: bool = False
+
+
 def ssl_channel_credentials(
     root_certificates: Optional[bytes] = None,
     private_key: Optional[bytes] = None,
     certificate_chain: Optional[bytes] = None,
 ) -> ChannelCredentials:
     return ChannelCredentials(root_certificates, private_key, certificate_chain)
+
+
+def ssl_server_credentials(
+    private_key_certificate_chain_pairs: Sequence[Tuple[bytes, bytes]],
+    *,
+    root_certificates: Optional[bytes] = None,
+    require_client_auth: bool = False,
+) -> ServerCredentials:
+    if not private_key_certificate_chain_pairs:
+        raise ValueError("At least one certificate pair is required")
+    # We only support a single key/cert pair in the shim.
+    private_key, certificate_chain = private_key_certificate_chain_pairs[0]
+    return ServerCredentials(
+        private_key=private_key,
+        certificate_chain=certificate_chain,
+        root_certificates=root_certificates,
+        require_client_auth=require_client_auth,
+    )
 
 
 class UnaryUnaryRpcMethodHandler:
@@ -126,6 +152,7 @@ from . import aio  # noqa: E402
 __all__ = [
     "AioRpcError",
     "ChannelCredentials",
+    "ServerCredentials",
     "GenericRpcHandler",
     "MetadataItem",
     "RpcError",
@@ -135,4 +162,5 @@ __all__ = [
     "aio",
     "method_handlers_generic_handler",
     "ssl_channel_credentials",
+    "ssl_server_credentials",
 ]

--- a/calculator_grpc/aio/__init__.py
+++ b/calculator_grpc/aio/__init__.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
+import ssl
+import tempfile
+from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
 from typing import Any, Iterable, Optional, Sequence, Tuple
 
@@ -12,6 +16,7 @@ from .. import (
     ChannelCredentials,
     GenericRpcHandler,
     MetadataItem,
+    ServerCredentials,
     ServicerContext,
     StatusCode,
     UnaryUnaryRpcMethodHandler,
@@ -68,7 +73,21 @@ class Channel:
             "data": request.to_dict(),
             "metadata": [(str(k), str(v)) for k, v in (metadata or ())],
         }
-        reader, writer = await asyncio.open_connection(self._host, self._port)
+        ssl_context_cm = (
+            _client_ssl_context(self._credentials)
+            if self._credentials
+            else nullcontext(None)
+        )
+        with ssl_context_cm as ssl_context:
+            connect_kwargs = {}
+            if ssl_context is not None:
+                connect_kwargs["ssl"] = ssl_context
+                connect_kwargs["server_hostname"] = self._host
+            reader, writer = await asyncio.open_connection(
+                self._host,
+                self._port,
+                **connect_kwargs,
+            )
         message = json.dumps(payload).encode("utf-8") + b"\n"
         writer.write(message)
         await writer.drain()
@@ -95,25 +114,50 @@ class Channel:
         return None
 
 
+@dataclass
+class _ServerTLSConfig:
+    ssl_context: ssl.SSLContext
+    temp_paths: list[str]
+
+
 class Server:
     def __init__(self) -> None:
         self._handlers: dict[str, dict[str, UnaryUnaryRpcMethodHandler]] = {}
         self._server: Optional[asyncio.AbstractServer] = None
         self._host = "127.0.0.1"
         self._port = 0
+        self._tls_config: Optional[_ServerTLSConfig] = None
 
     def add_generic_rpc_handlers(self, handlers: list[GenericRpcHandler]) -> None:
         for handler in handlers:
             self._handlers[handler.service_name] = handler.method_handlers
 
-    def add_insecure_port(self, target: str) -> str:
+    def add_insecure_port(self, target: str) -> int:
         host, port = target.split(":")
         self._host = host
         self._port = int(port)
-        return target
+        self._tls_config = None
+        return self._port
+
+    def add_secure_port(self, target: str, credentials: "ServerCredentials") -> int:
+        host, port = target.split(":")
+        self._host = host
+        self._port = int(port)
+        self._tls_config = _create_server_tls_config(credentials)
+        return self._port
 
     async def start(self) -> None:
-        self._server = await asyncio.start_server(self._handle_client, self._host, self._port)
+        ssl_context = self._tls_config.ssl_context if self._tls_config else None
+        self._server = await asyncio.start_server(
+            self._handle_client,
+            self._host,
+            self._port,
+            ssl=ssl_context,
+        )
+        if self._server.sockets:
+            sockname = self._server.sockets[0].getsockname()
+            if sockname and isinstance(sockname, tuple):
+                self._port = int(sockname[1])
 
     async def wait_for_termination(self) -> None:
         if self._server is None:
@@ -125,6 +169,17 @@ class Server:
         if self._server:
             self._server.close()
             await self._server.wait_closed()
+        if self._tls_config:
+            _cleanup_temp_paths(self._tls_config.temp_paths)
+            self._tls_config = None
+
+    @property
+    def bound_port(self) -> int:
+        if self._server and self._server.sockets:
+            sockname = self._server.sockets[0].getsockname()
+            if sockname and isinstance(sockname, tuple):
+                return int(sockname[1])
+        return self._port
 
     async def _handle_client(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
         raw = await reader.readline()
@@ -187,6 +242,73 @@ def secure_channel(
 
 def server() -> Server:
     return Server()
+
+
+@contextmanager
+def _client_ssl_context(credentials: ChannelCredentials | None):
+    if credentials is None:
+        yield None
+        return
+    context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
+    if credentials.root_certificates:
+        context.load_verify_locations(
+            cadata=_ensure_text(credentials.root_certificates)
+        )
+    else:
+        context.check_hostname = False
+        context.verify_mode = ssl.CERT_NONE
+    temp_paths: list[str] = []
+    try:
+        if credentials.certificate_chain and credentials.private_key:
+            cert_path = _write_temp_file(credentials.certificate_chain)
+            key_path = _write_temp_file(credentials.private_key)
+            temp_paths.extend([cert_path, key_path])
+            context.load_cert_chain(certfile=cert_path, keyfile=key_path)
+        yield context
+    finally:
+        _cleanup_temp_paths(temp_paths)
+
+
+def _create_server_tls_config(credentials: "ServerCredentials") -> _ServerTLSConfig:
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    temp_paths: list[str] = []
+    key_path = _write_temp_file(credentials.private_key)
+    cert_path = _write_temp_file(credentials.certificate_chain)
+    temp_paths.extend([key_path, cert_path])
+    try:
+        context.load_cert_chain(certfile=cert_path, keyfile=key_path)
+        if credentials.root_certificates:
+            context.load_verify_locations(
+                cadata=_ensure_text(credentials.root_certificates)
+            )
+        if credentials.require_client_auth:
+            context.verify_mode = ssl.CERT_REQUIRED
+    except Exception:
+        _cleanup_temp_paths(temp_paths)
+        raise
+    return _ServerTLSConfig(ssl_context=context, temp_paths=temp_paths)
+
+
+def _write_temp_file(data: bytes) -> str:
+    fd, path = tempfile.mkstemp()
+    with os.fdopen(fd, "wb") as handle:
+        handle.write(data)
+    return path
+
+
+def _cleanup_temp_paths(paths: Sequence[str]) -> None:
+    for path in paths:
+        try:
+            os.remove(path)
+        except FileNotFoundError:
+            continue
+
+
+def _ensure_text(data: bytes) -> str:
+    try:
+        return data.decode("utf-8")
+    except UnicodeDecodeError:
+        return data.decode("latin1")
 
 
 def _split_method(method: str) -> Tuple[str, str]:

--- a/services/common/__init__.py
+++ b/services/common/__init__.py
@@ -1,0 +1,1 @@
+"""Shared helpers across services."""

--- a/services/common/grpc.py
+++ b/services/common/grpc.py
@@ -1,0 +1,23 @@
+"""Compatibility layer for gRPC imports.
+
+The production code depends on ``grpcio``.  When the compiled package is not
+available (for example in offline kata environments), we fall back to the
+lightweight shim that lives in :mod:`calculator_grpc` so the rest of the
+application continues to run.  The shim implements the tiny subset of the
+``grpc`` API that our services rely on, including asyncio support and TLS
+handling.
+"""
+
+from __future__ import annotations
+
+try:  # pragma: no cover - exercised when grpcio is installed
+    import grpc as _grpc  # type: ignore
+    from grpc import aio as _grpc_aio  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - exercised in kata runtime
+    from calculator_grpc import aio as _grpc_aio  # type: ignore
+    import calculator_grpc as _grpc  # type: ignore
+
+grpc = _grpc
+aio = _grpc_aio
+
+__all__ = ["grpc", "aio"]

--- a/services/gateway/app/main.py
+++ b/services/gateway/app/main.py
@@ -8,7 +8,7 @@ import time
 from pathlib import Path
 from typing import Optional
 
-import grpc
+from services.common.grpc import grpc
 from opentelemetry import trace
 from opentelemetry.propagate import inject
 from opentelemetry.trace import SpanKind, Status, StatusCode

--- a/services/gateway/app/rate_limit.py
+++ b/services/gateway/app/rate_limit.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import time
+import uuid
 from typing import Final
 
 from redis.asyncio import Redis
@@ -24,7 +25,8 @@ class RateLimiter:
             return 0
         end
 
-        redis.call('ZADD', key, now, now)
+        local member = ARGV[5]
+        redis.call('ZADD', key, now, member)
         if ttl > 0 then
             redis.call('PEXPIRE', key, ttl)
         end
@@ -51,6 +53,7 @@ class RateLimiter:
         now_ms = int(time.time() * 1000)
         redis_key = f"{self._namespace}:{key}"
         ttl_ms = max(int(self._ttl * 1000), 0)
+        unique_member = f"{now_ms}:{uuid.uuid4().hex}"
         result = await self._redis.eval(
             self._LUA_SCRIPT,
             1,
@@ -59,5 +62,6 @@ class RateLimiter:
             self._window * 1000,
             self._limit,
             ttl_ms,
+            unique_member,
         )
         return bool(result)

--- a/services/protos/evaluator_pb2_grpc.py
+++ b/services/protos/evaluator_pb2_grpc.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Sequence
 
-import grpc
+from services.common.grpc import grpc
 
 from . import evaluator_pb2 as evaluator__pb2
 

--- a/services/safe_evaluator/app/server.py
+++ b/services/safe_evaluator/app/server.py
@@ -7,7 +7,7 @@ import logging
 from pathlib import Path
 from typing import Optional
 
-import grpc
+from services.common.grpc import grpc
 
 from .config import get_settings
 from .observability import configure_logging, configure_metrics, configure_tracing

--- a/services/safe_evaluator/app/service.py
+++ b/services/safe_evaluator/app/service.py
@@ -7,7 +7,7 @@ import time
 import uuid
 from typing import Dict, Iterable, List
 
-import grpc
+from services.common.grpc import grpc
 from opentelemetry import trace
 from opentelemetry.propagate import extract
 from opentelemetry.trace import SpanKind, Status, StatusCode

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+def _install_redis_stub() -> None:
+    parent = sys.modules.setdefault("redis", types.ModuleType("redis"))
+    module = types.ModuleType("redis.asyncio")
+    parent.asyncio = module  # type: ignore[attr-defined]
+
+    class _RedisStub:  # noqa: D401 - simple stand-in used in tests
+        pass
+
+    module.Redis = _RedisStub  # type: ignore[attr-defined]
+    sys.modules["redis.asyncio"] = module
+
+
+_install_redis_stub()
+
+
+def _load_rate_limit_module():
+    module_path = Path(__file__).resolve().parents[1] / "services/gateway/app/rate_limit.py"
+    spec = importlib.util.spec_from_file_location("calculator_gateway_rate_limit", module_path)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive guard
+        raise RuntimeError("Unable to load rate_limit module")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+rate_limit = _load_rate_limit_module()
+RateLimiter = rate_limit.RateLimiter
+
+
+class DummyRedis:
+    """Minimal Redis stub that exercises the Lua contract used by the limiter."""
+
+    def __init__(self) -> None:
+        self._buckets: dict[str, list[tuple[int, str]]] = {}
+
+    async def eval(
+        self,
+        script: str,
+        numkeys: int,
+        key: str,
+        now_ms: int,
+        window_ms: int,
+        limit: int,
+        ttl_ms: int,
+        member: str,
+    ) -> int:
+        assert "ARGV[5]" in script, "unique member argument must be consumed by the Lua script"
+        bucket = [entry for entry in self._buckets.get(key, []) if entry[0] > now_ms - window_ms]
+        if len(bucket) >= limit:
+            self._buckets[key] = bucket
+            return 0
+        bucket.append((now_ms, member))
+        self._buckets[key] = bucket
+        return 1
+
+
+def test_rate_limiter_enforces_burst_limits(monkeypatch: pytest.MonkeyPatch) -> None:
+    redis = DummyRedis()
+    limiter = RateLimiter(redis, limit=2, window_seconds=1, namespace="test")
+
+    monkeypatch.setattr(rate_limit.time, "time", lambda: 12345.0)
+
+    async def _run() -> None:
+        assert await limiter.allow("client")
+        assert await limiter.allow("client")
+        assert not await limiter.allow("client")
+
+    asyncio.run(_run())

--- a/tests/test_safe_evaluator_integration.py
+++ b/tests/test_safe_evaluator_integration.py
@@ -1,0 +1,330 @@
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from services.common.grpc import grpc
+from services.protos import evaluator_pb2, evaluator_pb2_grpc
+
+_SERVER_KEY = b"""-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCxPAAI1CuC267K\nLURdMtgFE5L22EnoIIJuQikgjp7XAdzqjTOwNAV3LaWaAFPegChxm/l8sK4jP10K\nOCBwxqN4wNU+ONK93gXSksdtCc64JaBn06sW0EO3Yj2kBiyVF00i2Maiv8Pxs6gf\nHclG+GuwU64gZkaYMMBp/i4rX5WyR+AOHls0ADqgioNz7ewILCGlhuGUZ3UZ8n88\n9zdJyGqvvz/WBPG829XJ+CB4xv1lWuHPpK3ZXnnTZyu4RtG+wb1GUx/nXKRNj6lq\nDJeeC734EfqA2Kyd5qRr1e+d8Eed1bKldZy8dbyzCDL8Qxql0vV0YpE9o1Z2eSpV\nBgcT3ZXnAgMBAAECggEAAZxFdc8TvCMp4e1qXxxsqRMl9Tc+6KyO8tiIDiMtn0+F\nhd4Vl6bJW+1ewVj6ah2pAGtF55OlaW2Ud1jONqgfaSP7bA7RH2eKjwDFbiC2L6cr\n33WlatYmn151p+1kb1BgY44rs+PhMGuM/gdjwlDUjawc+29iedSLkwr7uWorbozD\nxYuaG3kRQyw+aDGSvxycvnCxfNugTStZdmHpUZS0D/Cgyfc7bbM19NT/+i+BZv+o\nh90floODhHVIXOLw0whXeyBhf+Ec6yOAXhSXJH2iDzpIS/mGSYrpW40ODLBWx++h\nHSXkHMBp536OgECKFalWY1UtShDKpZ6HgM+a/hWXVQKBgQDbItKuy7ZAolb4Wj+u\n1b54AEfvTXyzsES1kSm7iAXFuQPMYNVLhqHmkE4meQQTXWe8q4o+AprXmQoR/YmL\n9XE8Vc6i6ynUM3H97DSPOsxv4NKYDW7iPcy0OAGsjN/wDQ3VW9i8i/NhePhRT2sb\nZohFgq5t3CfCUyMupVf39dNUwwKBgQDPDKqdHTKpSP/sEU5mLAprgPJ08RrVtKFD\nqRAHsI4i3DZNKDoDGO8Q9ApapQ/TrMlu25m0kADhOBXQykzD+If0KfelEW4CgYn/\n7hBAqyKyGa4SKmiaaedBCbzKKZ2S/LjL+QGSv2/N1Q3y8/krOYWPoRI7WbW8zREl\n4lw/1BAYDQKBgHPczp5C8ULtUqSPOxqawtE5/M7HHob3TOzfKryPp9WqBBscm8oK\nDjIU3G01EPWYLlAwNrCgufQCY7OtZPtOM6feCppTUlNzO/Mw331Xbl489bwVZipS\n2Jf1ANWVypVmoYjMviS6rl08E7cSEaR0KtrtxIIrpA333SM9ouxk2m73AoGBAKAx\nuqfI+XOE6Y2qbjAbDwzSPcVA7nQ+Ry9kVOS+M5rBKrpTz16qIf3J82DiqPYrj8ZX\n3fqYGDYpAKgEfZR6bCX7eoGalLUXqL/9X1HJlxSZTdb8POaL3cKyWAFKZYJeSlR2\nmkMCHuzwVNSO81AAN1hDVSnaZQRo3UWkd59i4fjZAoGBALFg5t7eIHJ604Rg/swH\nVUtWdoaMBX9r2ams8w/XHjXVUPBwfrDkkWDUcaNyRj299mHyEeBsuRUCnb7F3GRV\n/vLO1aR114ryIVczkXyPsaNpFGXJN20XHFagS4GFb3akooIhWfO2z6eqPjt4AAUT\nEXL6/F66zFyECNNqK0ptwpW8\n-----END PRIVATE KEY-----\n"""
+
+_SERVER_CERT = b"""-----BEGIN CERTIFICATE-----\nMIIDCTCCAfGgAwIBAgIUFXyWOzF/7LntgyEVWeaWgtad7vIwDQYJKoZIhvcNAQEL\nBQAwFDESMBAGA1UEAwwJbG9jYWxob3N0MB4XDTI1MTAwNDA5MTYyOVoXDTI2MTAw\nNDA5MTYyOVowFDESMBAGA1UEAwwJbG9jYWxob3N0MIIBIjANBgkqhkiG9w0BAQEF\nAAOCAQ8AMIIBCgKCAQEAsTwACNQrgtuuyi1EXTLYBROS9thJ6CCCbkIpII6e1wHc\n6o0zsDQFdy2lmgBT3oAocZv5fLCuIz9dCjggcMajeMDVPjjSvd4F0pLHbQnOuCWg\nZ9OrFtBDt2I9pAYslRdNItjGor/D8bOoHx3JRvhrsFOuIGZGmDDAaf4uK1+Vskfg\nDh5bNAA6oIqDc+3sCCwhpYbhlGd1GfJ/PPc3Schqr78/1gTxvNvVyfggeMb9ZVrh\nz6St2V5502cruEbRvsG9RlMf51ykTY+pagyXngu9+BH6gNisneaka9XvnfBHndWy\npXWcvHW8swgy/EMapdL1dGKRPaNWdnkqVQYHE92V5wIDAQABo1MwUTAdBgNVHQ4E\nFgQUVgo2+ySqqzxThyBIAy7aRJoenaswHwYDVR0jBBgwFoAUVgo2+ySqqzxThyBI\nAy7aRJoenaswDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAgKQN\ni6AKAF9R5cN1nkGrHGCqIbOjWnZ0bgJ6zQg3s+DczFTBKR7Huwar4QnSZbJJ7qiX\ncrxnbvMQeWeVx6mg3KbnwDtttIDAjCXG919cWNxumepPn+319qY4f0FbO6LE+p7a\n0yKlW/3/v7cLaFQiuwYQ3UK2bcBtm6fDSQAMFFvXNBmSy+tZ7R7BCT/Mqh4GaZL3\nZldA+gkT/xXHT/MOG6zc8/Y9FGB4gMvwD39tOHbAJrzJourPYZfckUG2AAHezrR3\nCVDqMfnOo+SKtoJ8+PrsPz+OLtlq+3vKg8JcchUIFYJO6YJIHc9ycdlq88RWH89Y\n1ZKkUq511aJKz+lbRw==\n-----END CERTIFICATE-----\n"""
+
+
+def _install_safe_evaluator_stubs() -> None:
+    otel = types.ModuleType("opentelemetry")
+
+    class _SpanContext:
+        def __init__(self) -> None:
+            self.trace_id = 0
+            self.span_id = 0
+
+        @property
+        def is_valid(self) -> bool:
+            return False
+
+    class _Span:
+        def __enter__(self) -> "_Span":
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:  # noqa: D401
+            return None
+
+        def set_attribute(self, *args, **kwargs) -> None:  # noqa: D401
+            return None
+
+        def set_status(self, *args, **kwargs) -> None:  # noqa: D401
+            return None
+
+        def record_exception(self, *args, **kwargs) -> None:  # noqa: D401
+            return None
+
+        def get_span_context(self) -> _SpanContext:
+            return _SpanContext()
+
+    class _Tracer:
+        def start_as_current_span(self, *args, **kwargs):  # noqa: D401
+            return _Span()
+
+    trace_module = types.ModuleType("opentelemetry.trace")
+    trace_module.get_tracer = lambda name: _Tracer()
+    trace_module.get_current_span = lambda: _Span()
+    trace_module.SpanKind = types.SimpleNamespace(SERVER="SERVER")
+
+    class _Status:
+        def __init__(self, code, description=None) -> None:  # noqa: D401
+            self.code = code
+            self.description = description
+
+    trace_module.Status = _Status
+    trace_module.StatusCode = types.SimpleNamespace(OK="OK", ERROR="ERROR")
+
+    def _set_tracer_provider(provider) -> None:  # noqa: D401
+        return None
+
+    trace_module.set_tracer_provider = _set_tracer_provider
+    otel.trace = trace_module
+
+    propagate_module = types.ModuleType("opentelemetry.propagate")
+    propagate_module.extract = lambda getter, carrier: None
+
+    exporter_module = types.ModuleType("opentelemetry.exporter")
+    proto_module = types.ModuleType("opentelemetry.exporter.otlp")
+    proto_http_module = types.ModuleType("opentelemetry.exporter.otlp.proto")
+    proto_http_module_http = types.ModuleType(
+        "opentelemetry.exporter.otlp.proto.http"
+    )
+    trace_exporter_module = types.ModuleType(
+        "opentelemetry.exporter.otlp.proto.http.trace_exporter"
+    )
+
+    class _OTLPSpanExporter:  # noqa: D401 - placeholder implementation
+        def __init__(self, *args, **kwargs) -> None:
+            return None
+
+    trace_exporter_module.OTLPSpanExporter = _OTLPSpanExporter
+    proto_http_module_http.trace_exporter = trace_exporter_module
+    proto_module.proto = types.SimpleNamespace(http=proto_http_module_http)
+    exporter_module.otlp = proto_module
+
+    sdk_module = types.ModuleType("opentelemetry.sdk")
+    resources_module = types.ModuleType("opentelemetry.sdk.resources")
+
+    class _Resource:
+        @staticmethod
+        def create(attrs):  # noqa: D401
+            return attrs
+
+    resources_module.Resource = types.SimpleNamespace(create=_Resource.create)
+    sdk_trace_module = types.ModuleType("opentelemetry.sdk.trace")
+
+    class _TracerProvider:
+        def __init__(self, *args, **kwargs) -> None:
+            self._processors = []
+
+        def add_span_processor(self, processor) -> None:  # noqa: D401
+            self._processors.append(processor)
+
+    sdk_trace_module.TracerProvider = _TracerProvider
+    export_module = types.ModuleType("opentelemetry.sdk.trace.export")
+
+    class _Processor:
+        def __init__(self, *args, **kwargs) -> None:
+            return None
+
+    export_module.BatchSpanProcessor = _Processor
+    export_module.ConsoleSpanExporter = _Processor
+    export_module.SimpleSpanProcessor = _Processor
+    sdk_trace_module.export = export_module
+    sdk_module.trace = sdk_trace_module
+    sdk_module.resources = resources_module
+
+    otel.exporter = exporter_module
+    otel.propagate = propagate_module
+    otel.sdk = sdk_module
+
+    sys.modules["opentelemetry"] = otel
+    sys.modules["opentelemetry.trace"] = trace_module
+    sys.modules["opentelemetry.propagate"] = propagate_module
+    sys.modules[
+        "opentelemetry.exporter.otlp.proto.http.trace_exporter"
+    ] = trace_exporter_module
+    sys.modules["opentelemetry.sdk.resources"] = resources_module
+    sys.modules["opentelemetry.sdk.trace"] = sdk_trace_module
+    sys.modules["opentelemetry.sdk.trace.export"] = export_module
+
+    prometheus = types.ModuleType("prometheus_client")
+
+    class _Metric:
+        def __init__(self, *args, **kwargs) -> None:
+            return None
+
+        def labels(self, **kwargs):  # noqa: D401
+            return self
+
+        def observe(self, *args, **kwargs) -> None:  # noqa: D401
+            return None
+
+        def inc(self, *args, **kwargs) -> None:  # noqa: D401
+            return None
+
+        def dec(self, *args, **kwargs) -> None:  # noqa: D401
+            return None
+
+    prometheus.Counter = _Metric
+    prometheus.Gauge = _Metric
+    prometheus.Histogram = _Metric
+    prometheus.start_http_server = lambda *args, **kwargs: None
+    sys.modules["prometheus_client"] = prometheus
+
+    jsonlogger_module = types.ModuleType("pythonjsonlogger.jsonlogger")
+
+    class _Formatter:
+        def __init__(self, *args, **kwargs) -> None:
+            return None
+
+        def format(self, record) -> str:  # noqa: D401
+            return str(record)
+
+    jsonlogger_module.JsonFormatter = _Formatter
+    sys.modules["pythonjsonlogger.jsonlogger"] = jsonlogger_module
+
+
+_install_safe_evaluator_stubs()
+
+
+def _load_evaluator_service_module():
+    module_path = Path(__file__).resolve().parents[1] / "services/safe_evaluator/app/service.py"
+    spec = importlib.util.spec_from_file_location("calculator_safe_evaluator_service", module_path)
+    if spec is None or spec.loader is None:  # pragma: no cover
+        raise RuntimeError("Unable to load evaluator service module")
+    root_services = Path(__file__).resolve().parents[1] / "services"
+    if "services" not in sys.modules:
+        services_pkg = types.ModuleType("services")
+        services_pkg.__path__ = [str(root_services)]  # type: ignore[attr-defined]
+        sys.modules["services"] = services_pkg
+    safe_root = module_path.parent.parent
+    if "services.safe_evaluator" not in sys.modules:
+        safe_pkg = types.ModuleType("services.safe_evaluator")
+        safe_pkg.__path__ = [str(safe_root)]  # type: ignore[attr-defined]
+        sys.modules["services.safe_evaluator"] = safe_pkg
+    package_name = "services.safe_evaluator.app"
+    if "services.safe_evaluator.app.config" not in sys.modules:
+        config_stub = types.ModuleType("services.safe_evaluator.app.config")
+
+        class _StubSettings:
+            pass
+
+        config_stub.EvaluatorSettings = _StubSettings
+        sys.modules["services.safe_evaluator.app.config"] = config_stub
+    if "services.safe_evaluator.app.observability" not in sys.modules:
+        observability_stub = types.ModuleType("services.safe_evaluator.app.observability")
+
+        def _noop(*args, **kwargs):  # noqa: D401
+            return None
+
+        observability_stub.configure_logging = _noop
+        observability_stub.configure_tracing = _noop
+        observability_stub.configure_metrics = _noop
+        observability_stub.increment_inflight = _noop
+        observability_stub.decrement_inflight = _noop
+        observability_stub.record_evaluation = _noop
+        observability_stub.record_sandbox_restart = _noop
+        observability_stub.set_request_id = lambda value: value
+        observability_stub.reset_request_id = _noop
+        sys.modules["services.safe_evaluator.app.observability"] = observability_stub
+    if package_name not in sys.modules:
+        package_module = types.ModuleType(package_name)
+        package_module.__path__ = [str(module_path.parent)]  # type: ignore[attr-defined]
+        sys.modules[package_name] = package_module
+    module = importlib.util.module_from_spec(spec)
+    module.__package__ = "services.safe_evaluator.app"
+    spec.loader.exec_module(module)
+    return module
+
+
+_service_module = _load_evaluator_service_module()
+EvaluatorService = _service_module.EvaluatorService
+
+
+def _build_settings() -> SimpleNamespace:
+    root = Path(__file__).resolve().parents[1]
+    allowlist = root / "services/safe_evaluator/app/allowlist.json"
+    return SimpleNamespace(
+        max_ast_depth=25,
+        max_ast_nodes=128,
+        max_complexity_score=1024,
+        max_runtime_seconds=0.25,
+        max_result_magnitude=1e12,
+        max_memory_bytes=64 * 1024 * 1024,
+        allowlist_path=allowlist,
+    )
+
+
+def test_evaluator_handles_valid_request_insecure() -> None:
+    async def _run() -> None:
+        with patch.object(_service_module, "SandboxRunner") as sandbox_mock, patch.object(
+            _service_module, "AllowListManager"
+        ) as allowlist_mock:
+            sandbox_instance = sandbox_mock.return_value
+            sandbox_instance.run.return_value = SimpleNamespace(
+                ok=True,
+                error=None,
+                duration_ms=12.3,
+                value=3.0,
+            )
+            allowlist_instance = allowlist_mock.return_value
+            allowlist_instance.snapshot.return_value = SimpleNamespace(
+                names=set(), symbols={}
+            )
+
+            server = grpc.aio.server()
+            service = EvaluatorService(_build_settings())
+            evaluator_pb2_grpc.add_EvaluatorServicer_to_server(service, server)
+            server.add_insecure_port("localhost:0")
+            await server.start()
+            port = server.bound_port
+
+            channel = grpc.aio.insecure_channel(f"localhost:{port}")
+            stub = evaluator_pb2_grpc.EvaluatorStub(channel)
+            try:
+                response = await stub.Evaluate(
+                    evaluator_pb2.EvaluateRequest(expression="1 + 2")
+                )
+                assert response.value == pytest.approx(3.0)
+                assert response.WhichOneof("result") == "value"
+            finally:
+                await channel.close()
+                await server.stop(0)
+
+    asyncio.run(_run())
+
+
+def test_evaluator_handles_valid_request_tls() -> None:
+    async def _run() -> None:
+        with patch.object(_service_module, "SandboxRunner") as sandbox_mock, patch.object(
+            _service_module, "AllowListManager"
+        ) as allowlist_mock:
+            sandbox_instance = sandbox_mock.return_value
+            sandbox_instance.run.return_value = SimpleNamespace(
+                ok=True,
+                error=None,
+                duration_ms=10.0,
+                value=3.0,
+            )
+            allowlist_instance = allowlist_mock.return_value
+            allowlist_instance.snapshot.return_value = SimpleNamespace(
+                names=set(), symbols={}
+            )
+
+            server = grpc.aio.server()
+            service = EvaluatorService(_build_settings())
+            evaluator_pb2_grpc.add_EvaluatorServicer_to_server(service, server)
+            server.add_secure_port(
+                "localhost:0",
+                grpc.ssl_server_credentials([(_SERVER_KEY, _SERVER_CERT)]),
+            )
+            await server.start()
+            port = server.bound_port
+
+            credentials = grpc.ssl_channel_credentials(root_certificates=_SERVER_CERT)
+            channel = grpc.aio.secure_channel(f"localhost:{port}", credentials)
+            stub = evaluator_pb2_grpc.EvaluatorStub(channel)
+            try:
+                response = await stub.Evaluate(
+                    evaluator_pb2.EvaluateRequest(expression="6 / 2")
+                )
+                assert response.value == pytest.approx(3.0)
+                assert response.WhichOneof("result") == "value"
+            finally:
+                await channel.close()
+                await server.stop(0)
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary
- replace the local grpc shim with a calculator_grpc package that supports TLS-aware channels and servers
- update gateway and evaluator services to import grpc through a shared compatibility module and fix the rate limiter’s Lua member handling
- add regression tests for the rate limiter and async evaluator RPC flow (insecure and TLS) using lightweight dependency stubs

## Testing
- pytest tests


------
https://chatgpt.com/codex/tasks/task_e_68e0e4981800832d8ed5f976606a6893