### PR TITLE
Add foundational job modeling and configuration

### DIFF
--- a/services/gateway/alembic/versions/20250205000001_add_jobs_table.py
+++ b/services/gateway/alembic/versions/20250205000001_add_jobs_table.py
@@ -1,0 +1,64 @@
+"""Add jobs table for asynchronous execution."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "20250205000001"
+down_revision = "20250101000000"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "jobs",
+        sa.Column("id", sa.String(length=36), primary_key=True),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("input_expression", sa.String(length=512), nullable=False),
+        sa.Column(
+            "context",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column(
+            "result_payload",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+        sa.Column("error", sa.Text(), nullable=True),
+        sa.Column(
+            "priority",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "tags",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+    )
+    op.create_index("ix_jobs_status", "jobs", ["status"])
+    op.create_index("ix_jobs_created_at", "jobs", ["created_at"])
+    op.create_index("ix_jobs_priority", "jobs", ["priority"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_jobs_priority", table_name="jobs")
+    op.drop_index("ix_jobs_created_at", table_name="jobs")
+    op.drop_index("ix_jobs_status", table_name="jobs")
+    op.drop_table("jobs")
+

--- a/services/gateway/app/config.py
+++ b/services/gateway/app/config.py
@@ -49,6 +49,13 @@ class QuotaSettings(BaseModel):
     window_seconds: int = 60
 
 
+class JobSettings(BaseModel):
+    default_ttl_seconds: int = 3600
+    max_queue_size: int = 1000
+    max_concurrency: int = 10
+    priority_levels: int = 3
+
+
 class GatewaySettings(BaseSettings):
     model_config = SettingsConfigDict(
         env_prefix="GATEWAY_",
@@ -64,6 +71,7 @@ class GatewaySettings(BaseSettings):
     evaluator: EvaluatorSettings = EvaluatorSettings()
     observability: ObservabilitySettings = ObservabilitySettings()
     quota: QuotaSettings = QuotaSettings()
+    job: JobSettings = JobSettings()
     audit_batch_size: int = 100
     cache_pure_results: bool = True
     allowed_origins: list[str] = ["*"]

--- a/services/gateway/app/models.py
+++ b/services/gateway/app/models.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import datetime as dt
-from typing import Optional
+from typing import Any, Dict, Optional
 
-from sqlalchemy import Boolean, DateTime, Float, ForeignKey, Index, Integer, String
+from sqlalchemy import Boolean, DateTime, Float, ForeignKey, Index, Integer, String, Text
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 
@@ -62,3 +63,26 @@ class Quota(Base):
     window_end: Mapped[dt.datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     usage: Mapped[int] = mapped_column(Integer, default=0)
     limit: Mapped[int] = mapped_column(Integer, default=0)
+
+
+class Job(Base):
+    __tablename__ = "jobs"
+    __table_args__ = (
+        Index("ix_jobs_status", "status"),
+        Index("ix_jobs_created_at", "created_at"),
+        Index("ix_jobs_priority", "priority"),
+    )
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    status: Mapped[str] = mapped_column(String(32), nullable=False)
+    created_at: Mapped[dt.datetime] = mapped_column(
+        DateTime(timezone=True), default=dt.datetime.utcnow, nullable=False
+    )
+    started_at: Mapped[Optional[dt.datetime]] = mapped_column(DateTime(timezone=True))
+    completed_at: Mapped[Optional[dt.datetime]] = mapped_column(DateTime(timezone=True))
+    input_expression: Mapped[str] = mapped_column(String(512), nullable=False)
+    context: Mapped[Dict[str, Any]] = mapped_column(JSONB, default=dict, nullable=False)
+    result_payload: Mapped[Optional[Dict[str, Any]]] = mapped_column(JSONB)
+    error: Mapped[Optional[str]] = mapped_column(Text)
+    priority: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    tags: Mapped[list[str]] = mapped_column(JSONB, default=list, nullable=False)

--- a/services/gateway/app/schemas.py
+++ b/services/gateway/app/schemas.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import datetime as dt
 import hashlib
 import re
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 PURE_ARITHMETIC_RE = re.compile(r"^[0-9+\-*/().\s]+$")
@@ -36,3 +37,27 @@ class CalculationResponse(BaseModel):
     error: Optional[str] = None
     duration_ms: float
     from_cache: bool = False
+
+
+class JobSubmissionRequest(BaseModel):
+    input_expression: str = Field(..., min_length=1, max_length=512)
+    context: Dict[str, float] = Field(default_factory=dict)
+    priority: int = Field(0, ge=0)
+    tags: list[str] = Field(default_factory=list)
+
+
+class JobStatusResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    status: str
+    created_at: dt.datetime
+    started_at: Optional[dt.datetime] = None
+    completed_at: Optional[dt.datetime] = None
+    priority: int
+    tags: list[str] = Field(default_factory=list)
+
+
+class JobResultResponse(JobStatusResponse):
+    result_payload: Optional[Dict[str, Any]] = None
+    error: Optional[str] = None


### PR DESCRIPTION
## Summary
- add SQLAlchemy Job model and related Pydantic schemas for async orchestration
- extend gateway settings with job configuration defaults
- create Alembic migration to introduce the jobs table and supporting indexes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0ff4c15b8832da572722f12d0918f