### PR TITLE
Add Celery-backed job queue and async job endpoints

### DIFF
--- a/services/gateway/app/cache.py
+++ b/services/gateway/app/cache.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from typing import Optional
+from typing import Any, Dict, Optional
 
 from redis.asyncio import Redis
 
@@ -34,3 +34,38 @@ class ResultCache:
 
     def _format_key(self, key: str) -> str:
         return f"{self._namespace}:{key}"
+
+
+class JobCache:
+    """Cache for job metadata stored as JSON payloads."""
+
+    def __init__(self, redis: Redis, ttl_seconds: int, namespace: str = "jobs") -> None:
+        self._redis = redis
+        self._ttl = ttl_seconds
+        self._namespace = namespace
+
+    async def get(self, job_id: str) -> Optional[Dict[str, Any]]:
+        raw = await self._redis.get(self._format_key(job_id))
+        if raw is None:
+            return None
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError:
+            return None
+        if not isinstance(payload, dict):
+            return None
+        return payload
+
+    async def set(self, job_id: str, payload: Dict[str, Any]) -> None:
+        serialized = json.dumps(payload)
+        redis_key = self._format_key(job_id)
+        if self._ttl > 0:
+            await self._redis.set(redis_key, serialized, ex=self._ttl)
+        else:
+            await self._redis.set(redis_key, serialized)
+
+    async def delete(self, job_id: str) -> None:
+        await self._redis.delete(self._format_key(job_id))
+
+    def _format_key(self, job_id: str) -> str:
+        return f"{self._namespace}:{job_id}"

--- a/services/gateway/app/config.py
+++ b/services/gateway/app/config.py
@@ -54,6 +54,13 @@ class JobSettings(BaseModel):
     max_queue_size: int = 1000
     max_concurrency: int = 10
     priority_levels: int = 3
+    queue_name: str = "calculator-jobs"
+    cache_namespace: str = "jobs"
+    rate_limit_requests: int = 5
+    rate_limit_window_seconds: int = 1
+    max_retries: int = 3
+    retry_backoff_seconds: float = 2.0
+    rate_namespace: str = "job_rate"
 
 
 class GatewaySettings(BaseSettings):

--- a/services/gateway/app/evaluator_client.py
+++ b/services/gateway/app/evaluator_client.py
@@ -1,0 +1,64 @@
+"""Helpers for interacting with the evaluator gRPC service."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Optional
+
+from opentelemetry.propagate import inject
+
+from services.common.grpc import aio as grpc_aio
+from services.common.grpc import grpc
+
+from .config import EvaluatorSettings
+
+
+def create_async_channel(settings: EvaluatorSettings) -> grpc_aio.Channel:
+    """Return an asynchronous gRPC channel for the evaluator."""
+
+    return _create_channel(settings, asynchronous=True)
+
+
+def create_sync_channel(settings: EvaluatorSettings) -> grpc.Channel:
+    """Return a synchronous gRPC channel for the evaluator."""
+
+    return _create_channel(settings, asynchronous=False)
+
+
+def build_grpc_metadata(*, request_id: Optional[str] = None, extra: Optional[Dict[str, str]] = None) -> list[tuple[str, str]]:
+    """Construct gRPC metadata including the current OpenTelemetry context."""
+
+    carrier: Dict[str, str] = {}
+    inject(carrier)
+    metadata = list(carrier.items())
+    if request_id:
+        metadata.append(("x-request-id", request_id))
+    if extra:
+        metadata.extend(extra.items())
+    return metadata
+
+
+def _create_channel(settings: EvaluatorSettings, *, asynchronous: bool):
+    target = f"{settings.host}:{settings.port}"
+    if settings.use_tls:
+        credentials = grpc.ssl_channel_credentials(
+            root_certificates=_read_optional_bytes(settings.root_cert_path),
+            private_key=_read_optional_bytes(settings.client_key_path),
+            certificate_chain=_read_optional_bytes(settings.client_cert_path),
+        )
+        if asynchronous:
+            return grpc_aio.secure_channel(target, credentials)
+        return grpc.secure_channel(target, credentials)
+    if asynchronous:
+        return grpc_aio.insecure_channel(target)
+    return grpc.insecure_channel(target)
+
+
+def _read_optional_bytes(path: Optional[Path]) -> Optional[bytes]:
+    if path is None:
+        return None
+    resolved = Path(path).expanduser()
+    if not resolved.exists():
+        raise RuntimeError(f"gRPC credential file not found: {resolved}")
+    return resolved.read_bytes()
+

--- a/services/gateway/app/jobs.py
+++ b/services/gateway/app/jobs.py
@@ -1,0 +1,101 @@
+"""Utilities for creating and serializing asynchronous jobs."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any, Dict, Iterable, Optional
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .cache import JobCache
+from .config import GatewaySettings
+from .models import Job
+from .schemas import JobResultResponse, JobSubmissionRequest
+
+STATUS_QUEUED = "queued"
+STATUS_RUNNING = "running"
+STATUS_SUCCEEDED = "succeeded"
+STATUS_FAILED = "failed"
+
+
+def normalize_priority(priority: int, *, levels: int) -> int:
+    if levels <= 0:
+        return 0
+    maximum = max(levels - 1, 0)
+    return max(0, min(priority, maximum))
+
+
+async def count_queued_jobs(session: AsyncSession) -> int:
+    stmt = select(func.count()).select_from(Job).where(Job.status == STATUS_QUEUED)
+    result = await session.execute(stmt)
+    return int(result.scalar_one())
+
+
+async def create_job(
+    session: AsyncSession,
+    submission: JobSubmissionRequest,
+    *,
+    settings: GatewaySettings,
+) -> Job:
+    job = Job(
+        id=str(uuid.uuid4()),
+        status=STATUS_QUEUED,
+        input_expression=submission.input_expression,
+        context=submission.context,
+        result_payload=None,
+        error=None,
+        priority=normalize_priority(submission.priority, levels=settings.job.priority_levels),
+        tags=_deduplicate_tags(submission.tags),
+    )
+    session.add(job)
+    await session.commit()
+    await session.refresh(job)
+    return job
+
+
+async def fetch_job(session: AsyncSession, job_id: str) -> Optional[Job]:
+    stmt = select(Job).where(Job.id == job_id)
+    result = await session.execute(stmt)
+    return result.scalars().first()
+
+
+def serialize_job(job: Job, settings: GatewaySettings, *, include_links: bool = True) -> Dict[str, Any]:
+    response = JobResultResponse.model_validate(job, from_attributes=True)
+    if include_links:
+        response.links = build_job_links(settings, job.id)
+    return response.model_dump(mode="json")
+
+
+def build_job_links(settings: GatewaySettings, job_id: str) -> Dict[str, str]:
+    base = f"/jobs/{job_id}"
+    return {
+        "self": base,
+        "poll": base,
+        "result": base,
+        "ws": f"/ws/jobs/{job_id}",
+    }
+
+
+async def write_job_cache(cache: JobCache, job: Job, settings: GatewaySettings) -> None:
+    await cache.set(job.id, serialize_job(job, settings))
+
+
+def _deduplicate_tags(tags: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    normalized: list[str] = []
+    for raw in tags:
+        if not isinstance(raw, str):
+            continue
+        candidate = raw.strip()
+        if not candidate:
+            continue
+        lowered = candidate.lower()
+        if lowered in seen:
+            continue
+        seen.add(lowered)
+        normalized.append(candidate)
+        if len(normalized) >= 32:
+            break
+    return normalized
+

--- a/services/gateway/app/main.py
+++ b/services/gateway/app/main.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from pathlib import Path
-from typing import Optional
 
 from services.common.grpc import grpc
 from opentelemetry import trace
@@ -19,9 +17,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from services.protos import evaluator_pb2, evaluator_pb2_grpc
 
-from .cache import ResultCache
-from .config import EvaluatorSettings, get_settings
+from . import jobs
+from .cache import JobCache, ResultCache
+from .config import get_settings
 from .database import get_session, init_db
+from .evaluator_client import build_grpc_metadata, create_async_channel
 from .instrumentation import (
     configure_logging,
     configure_tracing,
@@ -31,8 +31,14 @@ from .instrumentation import (
 from .models import RequestAudit
 from .quota import QuotaConfig, QuotaExceededError, consume_quota
 from .rate_limit import RateLimiter
-from .schemas import CalculationResponse, ExpressionRequest
+from .schemas import (
+    CalculationResponse,
+    ExpressionRequest,
+    JobResultResponse,
+    JobSubmissionRequest,
+)
 from .security import AuthenticatedAPIKey, get_api_key
+from .task_queue import enqueue_job
 
 logger = logging.getLogger(__name__)
 
@@ -54,6 +60,11 @@ async def startup_event() -> None:
         settings.redis.cache_ttl_seconds,
         namespace=settings.redis.cache_namespace,
     )
+    app.state.job_cache = JobCache(
+        app.state.redis,
+        settings.job.default_ttl_seconds,
+        namespace=settings.job.cache_namespace,
+    )
     rate_counter_ttl = settings.redis.rate_counter_ttl_seconds
     app.state.rate_limit_key = RateLimiter(
         app.state.redis,
@@ -69,12 +80,19 @@ async def startup_event() -> None:
         settings.redis.limiter_namespace,
         ttl_seconds=rate_counter_ttl,
     )
+    app.state.job_rate_limit_key = RateLimiter(
+        app.state.redis,
+        settings.job.rate_limit_requests,
+        settings.job.rate_limit_window_seconds,
+        settings.job.rate_namespace,
+        ttl_seconds=rate_counter_ttl,
+    )
     app.state.quota_config = QuotaConfig(
         limit=settings.quota.limit,
         window_seconds=settings.quota.window_seconds,
     )
     await init_db(settings)
-    app.state.grpc_channel = _create_grpc_channel(settings.evaluator)
+    app.state.grpc_channel = create_async_channel(settings.evaluator)
     app.state.grpc_stub = evaluator_pb2_grpc.EvaluatorStub(app.state.grpc_channel)
     logger.info("Gateway started on %s:%s", settings.host, settings.port)
 
@@ -169,7 +187,8 @@ async def calculate_sync(
 
     start_time = time.perf_counter()
     try:
-        metadata = _build_grpc_metadata(request)
+        request_id = getattr(request.state, "request_id", None)
+        metadata = build_grpc_metadata(request_id=request_id)
         with tracer.start_as_current_span(
             "gateway.grpc.evaluate",
             kind=SpanKind.CLIENT,
@@ -287,6 +306,70 @@ async def calculate(
     return await calculate_sync(payload, request, api_key=api_key, session=session)
 
 
+@app.post("/jobs", response_model=JobResultResponse, status_code=status.HTTP_202_ACCEPTED)
+async def submit_job(
+    payload: JobSubmissionRequest,
+    request: Request,
+    api_key: AuthenticatedAPIKey = Depends(require_api_key),
+    session: AsyncSession = Depends(get_session),
+) -> JobResultResponse:
+    api_key_id = api_key.record.id
+    job_rate_limiter: RateLimiter = app.state.job_rate_limit_key
+    if not await job_rate_limiter.allow(str(api_key_id)):
+        record_rate_limit_rejection("job_api_key")
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="API key job rate limit exceeded",
+        )
+
+    if settings.job.max_queue_size > 0:
+        queued_jobs = await jobs.count_queued_jobs(session)
+        if queued_jobs >= settings.job.max_queue_size:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Job queue is full",
+            )
+
+    try:
+        await consume_quota(session, api_key_id, app.state.quota_config)
+    except QuotaExceededError as exc:
+        raise HTTPException(status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail=str(exc)) from exc
+
+    job = await jobs.create_job(session, payload, settings=settings)
+    job_cache: JobCache = app.state.job_cache
+    job_payload = jobs.serialize_job(job, settings)
+    await job_cache.set(job.id, job_payload)
+
+    trace_headers: dict[str, str] = {}
+    inject(trace_headers)
+    request_id = getattr(request.state, "request_id", None)
+    if request_id:
+        trace_headers.setdefault("x-request-id", request_id)
+    enqueue_job(job.id, trace_context=trace_headers)
+
+    return JobResultResponse(**job_payload)
+
+
+@app.get("/jobs/{job_id}", response_model=JobResultResponse)
+async def get_job(
+    job_id: str,
+    api_key: AuthenticatedAPIKey = Depends(require_api_key),
+    session: AsyncSession = Depends(get_session),
+) -> JobResultResponse:
+    job_cache: JobCache = app.state.job_cache
+    cached = await job_cache.get(job_id)
+    if cached is not None:
+        return JobResultResponse(**cached)
+
+    job = await jobs.fetch_job(session, job_id)
+    if job is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
+
+    payload = jobs.serialize_job(job, settings)
+    await job_cache.set(job.id, payload)
+    return JobResultResponse(**payload)
+
+
 @app.get("/health/live")
 async def live() -> JSONResponse:
     return JSONResponse({"status": "ok"})
@@ -317,34 +400,3 @@ async def _persist_audit(
         session.add(audit)
         await session.commit()
         break
-
-
-def _create_grpc_channel(evaluator: EvaluatorSettings) -> grpc.aio.Channel:
-    target = f"{evaluator.host}:{evaluator.port}"
-    if evaluator.use_tls:
-        credentials = grpc.ssl_channel_credentials(
-            root_certificates=_read_optional_bytes(evaluator.root_cert_path),
-            private_key=_read_optional_bytes(evaluator.client_key_path),
-            certificate_chain=_read_optional_bytes(evaluator.client_cert_path),
-        )
-        return grpc.aio.secure_channel(target, credentials)
-    return grpc.aio.insecure_channel(target)
-
-
-def _read_optional_bytes(path: Optional[Path]) -> Optional[bytes]:
-    if path is None:
-        return None
-    resolved = Path(path).expanduser()
-    if not resolved.exists():
-        raise RuntimeError(f"gRPC credential file not found: {resolved}")
-    return resolved.read_bytes()
-
-
-def _build_grpc_metadata(request: Request) -> list[tuple[str, str]]:
-    carrier: dict[str, str] = {}
-    inject(carrier)
-    metadata = list(carrier.items())
-    request_id = getattr(request.state, "request_id", None)
-    if request_id:
-        metadata.append(("x-request-id", request_id))
-    return metadata

--- a/services/gateway/app/schemas.py
+++ b/services/gateway/app/schemas.py
@@ -56,6 +56,7 @@ class JobStatusResponse(BaseModel):
     completed_at: Optional[dt.datetime] = None
     priority: int
     tags: list[str] = Field(default_factory=list)
+    links: Dict[str, str] = Field(default_factory=dict)
 
 
 class JobResultResponse(JobStatusResponse):

--- a/services/gateway/app/task_queue.py
+++ b/services/gateway/app/task_queue.py
@@ -1,0 +1,269 @@
+"""Celery integration for distributing calculator jobs."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+import datetime as dt
+from typing import Any, Dict, Mapping, Optional
+
+from celery import Celery
+from celery.utils.log import get_task_logger
+from opentelemetry import trace
+from opentelemetry.context import attach, detach
+from opentelemetry.propagate import extract
+from opentelemetry.trace import Status, StatusCode
+from redis.asyncio import Redis
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from services.common.grpc import grpc
+from services.protos import evaluator_pb2, evaluator_pb2_grpc
+
+from .cache import JobCache
+from .config import get_settings
+from .evaluator_client import build_grpc_metadata, create_sync_channel
+from .jobs import (
+    STATUS_FAILED,
+    STATUS_QUEUED,
+    STATUS_RUNNING,
+    STATUS_SUCCEEDED,
+    serialize_job,
+)
+from .models import Job
+from .database import get_engine
+
+task_logger = get_task_logger(__name__)
+tracer = trace.get_tracer(__name__)
+
+settings = get_settings()
+
+celery_app = Celery("calculator-gateway")
+celery_app.conf.update(
+    broker_url=settings.redis.url,
+    result_backend=settings.redis.url,
+    task_default_queue=settings.job.queue_name,
+    task_serializer="json",
+    result_serializer="json",
+    accept_content=["json"],
+    task_acks_late=True,
+    task_track_started=True,
+    worker_prefetch_multiplier=1,
+)
+
+
+class TransientJobError(Exception):
+    """Raised to signal Celery that the job should be retried."""
+
+
+class JobExecutionError(Exception):
+    """Raised when the job ultimately fails."""
+
+
+_sync_channel = None
+_sync_stub: Optional[evaluator_pb2_grpc.EvaluatorStub] = None
+
+
+def enqueue_job(job_id: str, *, trace_context: Optional[Dict[str, str]] = None) -> None:
+    """Submit a job for asynchronous execution."""
+
+    celery_app.send_task(
+        name="gateway.execute_job",
+        args=[job_id],
+        kwargs={"trace_context": trace_context or {}},
+        queue=settings.job.queue_name,
+    )
+
+
+@celery_app.task(
+    bind=True,
+    name="gateway.execute_job",
+    autoretry_for=(TransientJobError,),
+    retry_backoff=settings.job.retry_backoff_seconds,
+    retry_jitter=True,
+    retry_kwargs={"max_retries": settings.job.max_retries},
+)
+def execute_job(self, job_id: str, trace_context: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
+    """Celery task entry point that coordinates job execution."""
+
+    parent_context = extract(trace_context or {})
+    token = attach(parent_context)
+    try:
+        return asyncio.run(
+            _execute_job(
+                job_id,
+                trace_headers=trace_context or {},
+                attempt=self.request.retries,
+                max_retries=self.max_retries or settings.job.max_retries,
+            )
+        )
+    finally:
+        detach(token)
+
+
+async def _execute_job(
+    job_id: str,
+    *,
+    trace_headers: Mapping[str, str],
+    attempt: int,
+    max_retries: int,
+) -> Dict[str, Any]:
+    start_time = time.perf_counter()
+    redis = Redis.from_url(settings.redis.url, decode_responses=True)
+    cache = JobCache(redis, settings.job.default_ttl_seconds, namespace=settings.job.cache_namespace)
+    engine = await get_engine(settings)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    try:
+        async with session_factory() as session:
+            job = await _lock_job(session, job_id)
+            if job is None:
+                task_logger.warning("Job %s not found", job_id)
+                return {"status": "missing"}
+
+            with tracer.start_as_current_span("worker.job", attributes={"job.id": job_id}) as span:
+                span.set_attribute("job.attempt", attempt)
+                span.set_attribute("job.max_retries", max_retries)
+                await _mark_running(session, job, cache)
+
+                try:
+                    response = await _invoke_evaluator(job, trace_headers)
+                except grpc.RpcError as exc:
+                    return await _handle_grpc_failure(
+                        session,
+                        job,
+                        cache,
+                        exc,
+                        attempt=attempt,
+                        max_retries=max_retries,
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    await _mark_failed(session, job, cache, str(exc))
+                    raise JobExecutionError(str(exc)) from exc
+
+                result_payload = _build_result_payload(response)
+                status = STATUS_SUCCEEDED if result_payload.get("value") is not None else STATUS_FAILED
+                await _finalize_job(session, job, cache, status=status, payload=result_payload)
+                span.set_attribute("job.status", status)
+                span.set_status(Status(StatusCode.OK))
+                duration_ms = (time.perf_counter() - start_time) * 1000.0
+                span.set_attribute("job.duration_ms", duration_ms)
+                return {
+                    "status": status,
+                    "result": result_payload,
+                    "duration_ms": duration_ms,
+                }
+    finally:
+        await redis.close()
+
+
+async def _lock_job(session, job_id: str) -> Optional[Job]:
+    stmt = select(Job).where(Job.id == job_id).with_for_update()
+    result = await session.execute(stmt)
+    return result.scalars().first()
+
+
+async def _mark_running(session, job: Job, cache: JobCache) -> None:
+    job.status = STATUS_RUNNING
+    job.started_at = dt.datetime.utcnow()
+    job.completed_at = None
+    job.error = None
+    await session.commit()
+    await cache.set(job.id, serialize_job(job, settings))
+
+
+async def _invoke_evaluator(job: Job, trace_headers: Mapping[str, str]):
+    stub = _get_sync_stub()
+    request = evaluator_pb2.EvaluateRequest(
+        expression=job.input_expression,
+        context={k: str(v) for k, v in job.context.items()},
+    )
+    metadata = build_grpc_metadata(extra=dict(trace_headers))
+    deadline = settings.evaluator.deadline_ms / 1000.0
+
+    with tracer.start_as_current_span(
+        "worker.job.evaluate",
+        attributes={"job.id": job.id, "rpc.method": "Evaluate"},
+    ):
+        return await asyncio.to_thread(
+            stub.Evaluate,
+            request,
+            timeout=deadline,
+            metadata=metadata,
+        )
+
+
+async def _handle_grpc_failure(
+    session,
+    job: Job,
+    cache: JobCache,
+    exc: grpc.RpcError,
+    *,
+    attempt: int,
+    max_retries: int,
+) -> Dict[str, Any]:
+    status_code = exc.code() if hasattr(exc, "code") else None
+    detail = exc.details() if hasattr(exc, "details") else None
+    if not detail and status_code is not None:
+        detail = status_code.name
+    if not detail:
+        detail = exc.__class__.__name__
+    task_logger.warning(
+        "Evaluator RPC failed for job %s: %s", job.id, detail, exc_info=exc if status_code is None else None
+    )
+
+    if status_code in {
+        grpc.StatusCode.UNAVAILABLE,
+        grpc.StatusCode.DEADLINE_EXCEEDED,
+        grpc.StatusCode.RESOURCE_EXHAUSTED,
+    } and attempt < max_retries:
+        job.status = STATUS_QUEUED
+        job.started_at = None
+        job.completed_at = None
+        job.error = detail
+        await session.commit()
+        await cache.set(job.id, serialize_job(job, settings))
+        raise TransientJobError(detail) from exc
+
+    await _mark_failed(session, job, cache, detail)
+    raise JobExecutionError(detail) from exc
+
+
+async def _mark_failed(session, job: Job, cache: JobCache, error: str) -> None:
+    job.status = STATUS_FAILED
+    job.completed_at = dt.datetime.utcnow()
+    job.error = error
+    job.result_payload = None
+    await session.commit()
+    await cache.set(job.id, serialize_job(job, settings))
+
+
+async def _finalize_job(
+    session,
+    job: Job,
+    cache: JobCache,
+    *,
+    status: str,
+    payload: Dict[str, Any],
+) -> None:
+    job.status = status
+    job.completed_at = dt.datetime.utcnow()
+    job.result_payload = payload if status == STATUS_SUCCEEDED else None
+    job.error = None if status == STATUS_SUCCEEDED else payload.get("error")
+    await session.commit()
+    await cache.set(job.id, serialize_job(job, settings))
+
+
+def _build_result_payload(response: evaluator_pb2.EvaluateResponse) -> Dict[str, Any]:
+    if response.WhichOneof("result") == "error":
+        return {"error": response.error, "duration_ms": response.duration_ms}
+    return {"value": response.value, "duration_ms": response.duration_ms}
+
+
+def _get_sync_stub() -> evaluator_pb2_grpc.EvaluatorStub:
+    global _sync_channel, _sync_stub
+    if _sync_stub is None:
+        _sync_channel = create_sync_channel(settings.evaluator)
+        _sync_stub = evaluator_pb2_grpc.EvaluatorStub(_sync_channel)
+    return _sync_stub
+

--- a/services/gateway/pyproject.toml
+++ b/services/gateway/pyproject.toml
@@ -27,6 +27,7 @@ opentelemetry-instrumentation-fastapi = "^0.46b0"
 opentelemetry-exporter-otlp-proto-http = "^1.25.0"
 python-json-logger = "^2.0.7"
 httpx = "^0.27.0"
+celery = "^5.3.6"
 calculator-core = {path = "../../libs/calculator_core", develop = true}
 calculator-logic = {path = "../../libs/calculator_logic", develop = true}
 

--- a/services/gateway/tests/test_gateway_endpoints.py
+++ b/services/gateway/tests/test_gateway_endpoints.py
@@ -3,15 +3,17 @@ import importlib
 import types
 from pathlib import Path
 import asyncio
+import datetime as dt
 from types import SimpleNamespace
 
 import pytest
-import pytest_asyncio
-from starlette import status
+from http import HTTPStatus
 
-ROOT = Path(__file__).resolve().parents[3]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
+REPO_ROOT = Path(__file__).resolve().parents[3]
+GATEWAY_ROOT = Path(__file__).resolve().parents[1]
+for candidate in (GATEWAY_ROOT, REPO_ROOT):
+    if str(candidate) not in sys.path:
+        sys.path.insert(0, str(candidate))
 
 from services.protos import evaluator_pb2
 
@@ -49,6 +51,17 @@ class StubCache:
         self.storage[key] = value
 
 
+class StubJobCache:
+    def __init__(self):
+        self.storage: dict[str, dict] = {}
+
+    async def get(self, job_id: str):
+        return self.storage.get(job_id)
+
+    async def set(self, job_id: str, payload: dict):
+        self.storage[job_id] = payload
+
+
 class StubEvaluatorStub:
     def __init__(self):
         self.calls: list[str] = []
@@ -79,8 +92,8 @@ async def fake_get_session():
     yield StubSession()
 
 
-@pytest_asyncio.fixture
-async def gateway_test_context(monkeypatch):
+@pytest.fixture
+def gateway_test_context(monkeypatch):
     for module in list(sys.modules):
         if module == "app" or module.startswith("app."):
             del sys.modules[module]
@@ -91,6 +104,68 @@ async def gateway_test_context(monkeypatch):
     stub_instrumentation.instrument_app = lambda app, settings: None
     stub_instrumentation.record_rate_limit_rejection = lambda reason: None
     sys.modules["app.instrumentation"] = stub_instrumentation
+
+    stub_opentelemetry = types.ModuleType("opentelemetry")
+
+    class _StubSpan:
+        def __init__(self):
+            self.attributes = {}
+
+        def set_attribute(self, key, value):
+            self.attributes[key] = value
+
+        def record_exception(self, exc):
+            return None
+
+        def set_status(self, status):
+            return None
+
+    class _SpanContextManager:
+        def __init__(self, *args, **kwargs):
+            self.span = _StubSpan()
+
+        def __enter__(self):
+            return self.span
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    class _StubTracer:
+        def start_as_current_span(self, *args, **kwargs):
+            return _SpanContextManager()
+
+    stub_trace = types.ModuleType("opentelemetry.trace")
+    stub_trace.get_tracer = lambda name=None: _StubTracer()
+    stub_trace.SpanKind = types.SimpleNamespace(CLIENT="client", SERVER="server")
+
+    class _StubStatus:
+        def __init__(self, code, description=None):
+            self.code = code
+            self.description = description
+
+    class _StubStatusCode:
+        OK = "OK"
+        ERROR = "ERROR"
+
+    stub_trace.Status = _StubStatus
+    stub_trace.StatusCode = _StubStatusCode
+
+    stub_propagate = types.ModuleType("opentelemetry.propagate")
+    stub_propagate.inject = lambda carrier: None
+    stub_propagate.extract = lambda carrier: {}
+
+    stub_context = types.ModuleType("opentelemetry.context")
+    stub_context.attach = lambda context: context
+    stub_context.detach = lambda token: None
+
+    stub_opentelemetry.trace = stub_trace
+    stub_opentelemetry.propagate = stub_propagate
+    stub_opentelemetry.context = stub_context
+
+    sys.modules["opentelemetry"] = stub_opentelemetry
+    sys.modules["opentelemetry.trace"] = stub_trace
+    sys.modules["opentelemetry.propagate"] = stub_propagate
+    sys.modules["opentelemetry.context"] = stub_context
 
     main = importlib.import_module("app.main")
     schemas = importlib.import_module("app.schemas")
@@ -105,7 +180,7 @@ async def gateway_test_context(monkeypatch):
     monkeypatch.setattr(main, "init_db", fake_init_db)
 
     stub_evaluator = StubEvaluatorStub()
-    monkeypatch.setattr(main, "_create_grpc_channel", lambda settings: StubChannel())
+    monkeypatch.setattr(main, "create_async_channel", lambda settings: StubChannel())
     monkeypatch.setattr(main.evaluator_pb2_grpc, "EvaluatorStub", lambda channel: stub_evaluator)
 
     recorded_audits = []
@@ -129,20 +204,81 @@ async def gateway_test_context(monkeypatch):
     async def override_require_api_key(request):
         key = request.headers.get("X-Api-Key")
         if not key:
-            raise main.HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing API key")
+            raise main.HTTPException(status_code=HTTPStatus.UNAUTHORIZED, detail="Missing API key")
         if key != "valid-key":
-            raise main.HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid API key")
+            raise main.HTTPException(status_code=HTTPStatus.UNAUTHORIZED, detail="Invalid API key")
         return security.AuthenticatedAPIKey(record=SimpleNamespace(id=123), raw_key=key)
 
     app.dependency_overrides[main.require_api_key] = override_require_api_key
 
     app.state.redis = StubRedis.from_url("redis://test")
     app.state.cache = StubCache()
+    app.state.job_cache = StubJobCache()
     app.state.rate_limit_key = StubRateLimiter()
     app.state.rate_limit_ip = StubRateLimiter()
+    app.state.job_rate_limit_key = StubRateLimiter()
     app.state.quota_config = main.QuotaConfig(limit=main.settings.quota.limit, window_seconds=main.settings.quota.window_seconds)
     app.state.grpc_channel = StubChannel()
     app.state.grpc_stub = stub_evaluator
+
+    recorded_jobs: dict[str, SimpleNamespace] = {}
+
+    async def fake_count_queued_jobs(session):
+        return fake_count_queued_jobs.value
+
+    fake_count_queued_jobs.value = 0
+
+    async def fake_create_job(session, submission, settings):
+        job_id = f"job-{len(recorded_jobs) + 1}"
+        job = SimpleNamespace(
+            id=job_id,
+            status="queued",
+            created_at=dt.datetime.utcnow(),
+            started_at=None,
+            completed_at=None,
+            priority=submission.priority,
+            tags=list(submission.tags),
+            context=submission.context,
+            input_expression=submission.input_expression,
+            result_payload=None,
+            error=None,
+        )
+        recorded_jobs[job_id] = job
+        return job
+
+    def fake_serialize_job(job, settings):
+        return {
+            "id": job.id,
+            "status": job.status,
+            "created_at": job.created_at.isoformat(),
+            "started_at": job.started_at.isoformat() if job.started_at else None,
+            "completed_at": job.completed_at.isoformat() if job.completed_at else None,
+            "priority": job.priority,
+            "tags": list(job.tags),
+            "links": {
+                "self": f"/jobs/{job.id}",
+                "poll": f"/jobs/{job.id}",
+                "result": f"/jobs/{job.id}",
+                "ws": f"/ws/jobs/{job.id}",
+            },
+            "result_payload": job.result_payload,
+            "error": job.error,
+        }
+
+    async def fake_fetch_job(session, job_id):
+        return recorded_jobs.get(job_id)
+
+    monkeypatch.setattr(main.jobs, "count_queued_jobs", fake_count_queued_jobs)
+    monkeypatch.setattr(main.jobs, "create_job", fake_create_job)
+    monkeypatch.setattr(main.jobs, "serialize_job", fake_serialize_job)
+    monkeypatch.setattr(main.jobs, "fetch_job", fake_fetch_job)
+
+    enqueue_calls: list[dict] = []
+
+    def fake_enqueue_job(job_id: str, trace_context=None):
+        enqueue_calls.append({"id": job_id, "trace": trace_context or {}})
+
+    monkeypatch.setattr(main, "enqueue_job", fake_enqueue_job)
 
     yield {
         "main": main,
@@ -154,18 +290,28 @@ async def gateway_test_context(monkeypatch):
         "rate_limiter_ip": app.state.rate_limit_ip,
         "recorded_audits": recorded_audits,
         "consume_quota": fake_consume_quota,
+        "job_cache": app.state.job_cache,
+        "job_rate_limiter": app.state.job_rate_limit_key,
+        "enqueue_job_calls": enqueue_calls,
+        "jobs_storage": recorded_jobs,
+        "count_queued_jobs": fake_count_queued_jobs,
+        "create_job_stub": fake_create_job,
     }
 
     recorded_audits.clear()
     app.dependency_overrides.clear()
     sys.modules.pop("app.instrumentation", None)
+    sys.modules.pop("opentelemetry", None)
+    sys.modules.pop("opentelemetry.trace", None)
+    sys.modules.pop("opentelemetry.propagate", None)
+    sys.modules.pop("opentelemetry.context", None)
 
 
-def _make_request(host="127.0.0.1"):
+def _make_request(host="127.0.0.1", *, method="POST", path="/calculate"):
     scope = {
         "type": "http",
-        "method": "POST",
-        "path": "/calculate",
+        "method": method,
+        "path": path,
         "headers": [],
         "client": (host, 1234),
     }
@@ -174,8 +320,7 @@ def _make_request(host="127.0.0.1"):
     return Request(scope, receive=lambda: None)
 
 
-@pytest.mark.asyncio
-async def test_calculate_success_invokes_evaluator(gateway_test_context):
+def test_calculate_success_invokes_evaluator(gateway_test_context):
     ctx = gateway_test_context
     main = ctx["main"]
     ExpressionRequest = ctx["schemas"].ExpressionRequest
@@ -186,17 +331,16 @@ async def test_calculate_success_invokes_evaluator(gateway_test_context):
     api_key = AuthenticatedAPIKey(record=SimpleNamespace(id=123), raw_key="valid-key")
     session = StubSession()
 
-    response = await main.calculate_sync(payload, request, api_key=api_key, session=session)
+    response = asyncio.run(main.calculate_sync(payload, request, api_key=api_key, session=session))
 
     assert response.value == pytest.approx(3.0)
     assert response.from_cache is False
     assert len(ctx["evaluator"].calls) == 1
-    await asyncio.sleep(0)
+    asyncio.run(asyncio.sleep(0))
     assert ctx["recorded_audits"], "audit log should capture success"
 
 
-@pytest.mark.asyncio
-async def test_calculate_uses_cache_on_repeated_calls(gateway_test_context):
+def test_calculate_uses_cache_on_repeated_calls(gateway_test_context):
     ctx = gateway_test_context
     main = ctx["main"]
     ExpressionRequest = ctx["schemas"].ExpressionRequest
@@ -207,15 +351,14 @@ async def test_calculate_uses_cache_on_repeated_calls(gateway_test_context):
     api_key = AuthenticatedAPIKey(record=SimpleNamespace(id=123), raw_key="valid-key")
     session = StubSession()
 
-    first = await main.calculate_sync(payload, request, api_key=api_key, session=session)
+    first = asyncio.run(main.calculate_sync(payload, request, api_key=api_key, session=session))
     assert first.from_cache is False
-    second = await main.calculate_sync(payload, request, api_key=api_key, session=session)
+    second = asyncio.run(main.calculate_sync(payload, request, api_key=api_key, session=session))
     assert second.from_cache is True
     assert len(ctx["evaluator"].calls) == 1
 
 
-@pytest.mark.asyncio
-async def test_rate_limit_rejection_returns_http_429(gateway_test_context):
+def test_rate_limit_rejection_returns_http_429(gateway_test_context):
     ctx = gateway_test_context
     main = ctx["main"]
     ExpressionRequest = ctx["schemas"].ExpressionRequest
@@ -228,13 +371,89 @@ async def test_rate_limit_rejection_returns_http_429(gateway_test_context):
     session = StubSession()
 
     with pytest.raises(main.HTTPException) as exc:
-        await main.calculate_sync(payload, request, api_key=api_key, session=session)
+        asyncio.run(main.calculate_sync(payload, request, api_key=api_key, session=session))
 
-    assert exc.value.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+    assert exc.value.status_code == HTTPStatus.TOO_MANY_REQUESTS
 
 
-@pytest.mark.asyncio
-async def test_quota_exceeded_returns_http_429(gateway_test_context):
+def test_submit_job_enqueues_and_caches_metadata(gateway_test_context):
+    ctx = gateway_test_context
+    main = ctx["main"]
+    JobSubmissionRequest = ctx["schemas"].JobSubmissionRequest
+    AuthenticatedAPIKey = ctx["security"].AuthenticatedAPIKey
+
+    payload = JobSubmissionRequest(input_expression="1+2")
+    request = _make_request(path="/jobs")
+    api_key = AuthenticatedAPIKey(record=SimpleNamespace(id=123), raw_key="valid-key")
+    session = StubSession()
+
+    response = asyncio.run(main.submit_job(payload, request, api_key=api_key, session=session))
+
+    assert response.status == "queued"
+    assert ctx["enqueue_job_calls"], "job dispatch should be recorded"
+    job_id = ctx["enqueue_job_calls"][0]["id"]
+    assert job_id == response.id
+    cached = asyncio.run(ctx["job_cache"].get(job_id))
+    assert cached["id"] == job_id
+
+
+def test_submit_job_rate_limited_returns_http_429(gateway_test_context):
+    ctx = gateway_test_context
+    main = ctx["main"]
+    JobSubmissionRequest = ctx["schemas"].JobSubmissionRequest
+    AuthenticatedAPIKey = ctx["security"].AuthenticatedAPIKey
+
+    ctx["job_rate_limiter"].allowed = False
+    payload = JobSubmissionRequest(input_expression="sin(0)")
+    request = _make_request(path="/jobs")
+    api_key = AuthenticatedAPIKey(record=SimpleNamespace(id=123), raw_key="valid-key")
+    session = StubSession()
+
+    with pytest.raises(main.HTTPException) as exc:
+        asyncio.run(main.submit_job(payload, request, api_key=api_key, session=session))
+
+    assert exc.value.status_code == HTTPStatus.TOO_MANY_REQUESTS
+
+
+def test_submit_job_queue_full_returns_503(gateway_test_context):
+    ctx = gateway_test_context
+    main = ctx["main"]
+    JobSubmissionRequest = ctx["schemas"].JobSubmissionRequest
+    AuthenticatedAPIKey = ctx["security"].AuthenticatedAPIKey
+
+    ctx["count_queued_jobs"].value = main.settings.job.max_queue_size
+    payload = JobSubmissionRequest(input_expression="3*3")
+    request = _make_request(path="/jobs")
+    api_key = AuthenticatedAPIKey(record=SimpleNamespace(id=123), raw_key="valid-key")
+    session = StubSession()
+
+    with pytest.raises(main.HTTPException) as exc:
+        asyncio.run(main.submit_job(payload, request, api_key=api_key, session=session))
+
+    assert exc.value.status_code == HTTPStatus.SERVICE_UNAVAILABLE
+    ctx["count_queued_jobs"].value = 0
+
+
+def test_get_job_fetches_from_persistence_when_cache_miss(gateway_test_context):
+    ctx = gateway_test_context
+    main = ctx["main"]
+    AuthenticatedAPIKey = ctx["security"].AuthenticatedAPIKey
+    JobSubmissionRequest = ctx["schemas"].JobSubmissionRequest
+
+    submission = JobSubmissionRequest(input_expression="4+4")
+    job = asyncio.run(ctx["create_job_stub"](StubSession(), submission, settings=main.settings))
+    ctx["job_cache"].storage.pop(job.id, None)
+
+    api_key = AuthenticatedAPIKey(record=SimpleNamespace(id=123), raw_key="valid-key")
+    session = StubSession()
+
+    response = asyncio.run(main.get_job(job.id, api_key=api_key, session=session))
+
+    assert response.id == job.id
+    assert asyncio.run(ctx["job_cache"].get(job.id)) is not None
+
+
+def test_quota_exceeded_returns_http_429(gateway_test_context):
     ctx = gateway_test_context
     main = ctx["main"]
     ExpressionRequest = ctx["schemas"].ExpressionRequest
@@ -247,13 +466,12 @@ async def test_quota_exceeded_returns_http_429(gateway_test_context):
     session = StubSession()
 
     with pytest.raises(main.HTTPException) as exc:
-        await main.calculate_sync(payload, request, api_key=api_key, session=session)
+        asyncio.run(main.calculate_sync(payload, request, api_key=api_key, session=session))
 
-    assert exc.value.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+    assert exc.value.status_code == HTTPStatus.TOO_MANY_REQUESTS
 
 
-@pytest.mark.asyncio
-async def test_require_api_key_missing_header_raises_401(gateway_test_context):
+def test_require_api_key_missing_header_raises_401(gateway_test_context):
     ctx = gateway_test_context
     main = ctx["main"]
 
@@ -263,6 +481,6 @@ async def test_require_api_key_missing_header_raises_401(gateway_test_context):
     request = Request(scope, receive=lambda: None)
 
     with pytest.raises(main.HTTPException) as exc:
-        await main.require_api_key(request, session=StubSession())
+        asyncio.run(main.require_api_key(request, session=StubSession()))
 
-    assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED
+    assert exc.value.status_code == HTTPStatus.UNAUTHORIZED


### PR DESCRIPTION
## Summary
- add a Celery-driven task queue and evaluator client helpers for worker execution
- extend the gateway with job submission and status endpoints plus Redis-backed job caching and rate limiting
- expand configuration and tests to cover queued job orchestration and Celery integration

## Testing
- pytest *(fails: missing fastapi dependency in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e10169f714832d9cc6176152b966c4