### PR TITLE
Add async job observability metrics and runbooks

### DIFF
--- a/CALCULATOR_USAGE.txt
+++ b/CALCULATOR_USAGE.txt
@@ -53,6 +53,36 @@ Local Development (without Docker)
    make run-gateway
    ````
 
+Asynchronous Jobs
+-----------------
+Phase 2 adds an async job API backed by Celery and Redis. Use it for heavyweight expressions or batch workloads.
+
+1. Submit a job:
+   ````bash
+   curl -X POST http://localhost:8080/jobs \
+     -H "X-Api-Key: <your-key>" \
+     -H "Content-Type: application/json" \
+     -d '{
+           "input_expression": "pow(2, 12) + sqrt(16)",
+           "context": {"scale": 3},
+           "priority": 1,
+           "tags": ["demo", "retryable"]
+         }'
+   ````
+   The response returns the job metadata, including polling links and WebSocket URI (`/ws/jobs/<id>`).
+2. Poll for completion:
+   ````bash
+   curl -H "X-Api-Key: <your-key>" http://localhost:8080/jobs/<job-id>
+   ````
+   Successful jobs return the cached payload; failures include the error string recorded in Postgres and Prometheus (`calculator_gateway_jobs_failed_total`).
+3. Optional: stream updates over WebSockets (requires `wscat` or similar):
+   ````bash
+   npx wscat -c ws://localhost:8080/ws/jobs/<job-id> -H "X-Api-Key: <your-key>"
+   ````
+4. Explore metrics and dashboards:
+   - `curl -s http://localhost:8080/metrics | grep calculator_gateway_job`
+   - Grafana → `Gateway Overview` → Async panels for throughput, success rate, and wait time.
+
 Testing
 -------
 Execute unit tests from the repository root:

--- a/docs/ADRS/ADR-004-queue-technology.md
+++ b/docs/ADRS/ADR-004-queue-technology.md
@@ -1,0 +1,38 @@
+# ADR-004: Queue Technology for Asynchronous Jobs
+
+* **Status:** Accepted
+* **Date:** 2025-02-10
+
+## Context
+
+Phase 2 introduces asynchronous job orchestration for the calculator platform. We need a task queue that can:
+
+* Integrate with the existing FastAPI gateway with minimal operational overhead.
+* Support delayed execution, retries with backoff, and visibility into worker state.
+* Run within the Phase 1 deployment footprint (Docker Compose today, Kubernetes later) without requiring dedicated broker clusters beyond Redis/Postgres already provisioned.
+* Expose hooks for observability so that Phase 1 OpenTelemetry and Prometheus instrumentation can extend across enqueue → execution → completion.
+
+Candidate technologies evaluated:
+
+* **Celery (Redis broker):** Mature, Python-native, battle-tested retry semantics, task introspection via `celery inspect`, large ecosystem of monitoring tools. Native support for custom instrumentation and pluggable serializers.
+* **Arq:** Lightweight asyncio-focused queue that speaks Redis directly. Small dependency footprint but limited ecosystem for worker management, introspection, and scheduling.
+* **RQ:** Simple to operate (Redis only) but lacks native retry backoff, rate limits, or built-in task progress reporting without third-party extensions.
+* **RabbitMQ + Celery:** Provides strong delivery guarantees but introduces an additional broker to provision, monitor, and secure.
+
+## Decision
+
+Adopt **Celery with Redis** as the task orchestrator, embedding it inside the gateway service for now. Key reasons:
+
+1. **Operational reuse:** Redis is already part of the Phase 1 stack. Celery can share the broker for both task dispatch and job cache metadata, avoiding new infrastructure.
+2. **Rich lifecycle controls:** Celery exposes retries, acks late, task revocation, rate limiting, and worker pools—requirements for sandboxed evaluations that may time out or need replay.
+3. **Observability hooks:** Celery surfaces task signals that map cleanly to OpenTelemetry spans and Prometheus counters. The instrumentation in `task_queue.py` emits queue depth, in-progress gauges, and runtime histograms without custom forks.
+4. **Future scalability:** As we move toward Kubernetes, Celery's worker autoscaling patterns (`control add_consumer`, `cancel_consumer`, `pool_grow/shrink`) align with HPA and KEDA integrations.
+
+Arq and RQ were rejected because they would require building missing retry/backoff primitives ourselves and lack the diagnostic tooling expected for Phase 2. RabbitMQ was deferred because adding and operating a second broker would slow delivery and complicate disaster recovery without delivering compelling benefits at our current scale.
+
+## Consequences
+
+* The gateway now depends on Celery worker processes; deployments must start the worker pool alongside the FastAPI application.
+* Redis availability becomes even more critical—runbook updates cover cache rebuilds and queue purges after broker outages.
+* Developers should familiarize themselves with Celery CLI tooling (`inspect`, `control`, `purge`) and the metrics emitted (`jobs_enqueued_total`, `job_queue_depth`, etc.).
+* The architecture leaves room to extract the task orchestrator into its own service later; the ADR captures the rationale should future requirements favor an alternate broker.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -51,12 +51,39 @@ The Compose environment now ships a full observability suite wired end-to-end:
 * **Tracing:** Both the FastAPI gateway and gRPC evaluator emit OpenTelemetry traces with W3C context propagation (`traceparent` header → gRPC metadata). Spans are exported to Tempo via OTLP/HTTP (`http://tempo:4318/v1/traces`).
 * **Metrics:**
   - Gateway exposes Prometheus metrics on `:8080/metrics`, including request counters (`calculator_gateway_requests_total`), latency histograms, and a rolling gauge of rate-limit rejections per reason.
+  - Phase 2 introduces dedicated asynchronous job series: `calculator_gateway_jobs_enqueued_total`, `calculator_gateway_jobs_in_progress`, `calculator_gateway_jobs_failed_total{reason=...}`, queue depth gauge (`calculator_gateway_job_queue_depth`), worker runtime histogram (`calculator_gateway_job_task_runtime_seconds_bucket`), and queue wait histogram (`calculator_gateway_job_queue_wait_seconds_bucket`).
   - The evaluator publishes metrics on `:9464` covering execution duration histograms, in-flight queue depth, sandbox restart counters, and default process resource gauges.
   - Prometheus scrapes both endpoints (`observability/prometheus.yml`).
 * **Logging:** Structured JSON logs with `request_id`, `trace_id`, and `span_id` are shipped to Loki via a Promtail sidecar that tails Docker logs (`observability/promtail-config.yaml`).
-* **Dashboards & Alerts:** Grafana is pre-provisioned with data sources, dashboards (`Gateway Overview`, `Evaluator Health`), and alert rules. Dashboards live under `observability/grafana/dashboards/`; provisioning (data sources, alert contact points, notification policies, rules) is in `observability/grafana/provisioning/`.
+* **Dashboards & Alerts:** Grafana is pre-provisioned with data sources, dashboards (`Gateway Overview`, `Evaluator Health`), and alert rules. Dashboards live under `observability/grafana/dashboards/`; provisioning (data sources, alert contact points, notification policies, rules) is in `observability/grafana/provisioning/`. The `Gateway Overview` board now includes async job throughput, success rate, and average wait time panels fed by the metrics above.
 
 > Tip: `docker compose -f docker-compose.phase1.yml up --build` launches the entire stack. Grafana is reachable on `http://localhost:3000` (admin password `grafana`).
+
+## Job Management Commands
+
+Day-to-day asynchronous job operations rely on the Celery application defined in `services.gateway.app.task_queue`.
+
+* Inspect active workers, registered tasks, and queue statistics:
+  ```bash
+  celery -A services.gateway.app.task_queue inspect active
+  celery -A services.gateway.app.task_queue inspect stats
+  celery -A services.gateway.app.task_queue inspect registered
+  ```
+* Monitor queue depth via Redis and Prometheus concurrently:
+  ```bash
+  celery -A services.gateway.app.task_queue inspect active_queues
+  curl -s http://localhost:8080/metrics | grep calculator_gateway_job_queue_depth
+  ```
+* Purge messages or failed retries (use sparingly and coordinate with the runbook below):
+  ```bash
+  celery -A services.gateway.app.task_queue purge
+  celery -A services.gateway.app.task_queue control discard all
+  ```
+* Scale workers horizontally:
+  ```bash
+  celery -A services.gateway.app.task_queue control add_consumer calculator-jobs -d worker@%h
+  celery -A services.gateway.app.task_queue control cancel_consumer calculator-jobs -d worker@%h
+  ```
 
 ## Securing Gateway ↔ Evaluator Traffic
 
@@ -124,6 +151,84 @@ Mutual TLS is optional—leave `EVALUATOR_CLIENT_CA_PATH` unset to accept TLS wi
 * **Redis outage:** Pause the Redis container; the gateway should continue serving requests without caching but still enforce quotas from Postgres.
 * **Load tests:** Use the provided Locust plan (`tests/load/locustfile.py`) or complementary tools such as `k6` to validate throughput targets. Focus on ensuring rate limits and cache hit ratios behave as expected.
 
+## Asynchronous Job Runbooks
+
+### Handling Stuck Jobs
+
+1. Confirm that the job is no longer updating by inspecting Redis and Postgres:
+   ```bash
+   celery -A services.gateway.app.task_queue inspect active --timeout=10
+   curl -s http://localhost:8080/metrics | grep calculator_gateway_jobs_in_progress
+   ```
+2. Locate the job metadata (status, attempt count, worker hostname) via SQL:
+   ```bash
+   psql $GATEWAY_DATABASE__URL -c "SELECT id, status, started_at, error FROM jobs WHERE id = '<job-id>'"
+   ```
+3. If a worker is wedged, revoke the task and optionally terminate the worker process:
+   ```bash
+   celery -A services.gateway.app.task_queue control revoke <job-id> --terminate --signal=SIGTERM
+   ```
+4. Reset the job back to queued status and re-enqueue when safe:
+   ```bash
+   psql $GATEWAY_DATABASE__URL -c "UPDATE jobs SET status='queued', started_at=NULL, completed_at=NULL, error=NULL WHERE id='<job-id>'"
+   python - <<'PY'
+   from services.gateway.app.task_queue import enqueue_job
+
+   enqueue_job("<job-id>")
+   PY
+   ```
+5. Track recovery on Grafana (`Gateway Overview → Async Job Throughput`) and via the `calculator_gateway_job_queue_depth` gauge.
+
+### Clearing Failed Queue
+
+1. Quantify failures and reasons:
+   ```bash
+   curl -s http://localhost:8080/metrics | grep calculator_gateway_jobs_failed_total
+   psql $GATEWAY_DATABASE__URL -c "SELECT id, error FROM jobs WHERE status='failed' ORDER BY completed_at DESC LIMIT 50"
+   ```
+2. Requeue idempotent jobs in bulk:
+   ```bash
+   psql $GATEWAY_DATABASE__URL -c "UPDATE jobs SET status='queued', error=NULL WHERE status='failed' AND tags @> '{"retryable"}'"
+   python - <<'PY'
+   from services.gateway.app.task_queue import enqueue_job
+
+   enqueue_job("<job-id>")
+   PY
+   ```
+3. Purge irrecoverable messages from Redis to free capacity:
+   ```bash
+   celery -A services.gateway.app.task_queue purge
+   ```
+4. Create a postmortem entry noting root cause, affected tenants, and remediation. Update Grafana annotations if required.
+
+### Scaling Workers
+
+1. Watch the Prometheus series `calculator_gateway_job_queue_depth` and `calculator_gateway_jobs_in_progress`.
+2. Scale out when the queue depth exceeds 75% of `GATEWAY_JOB__MAX_QUEUE_SIZE` or when `jobs_in_progress` stays near concurrency for five minutes.
+3. Add workers:
+   ```bash
+   celery -A services.gateway.app.task_queue worker --loglevel=info --queues calculator-jobs --hostname worker@%h
+   ```
+4. Verify heartbeats and throughput in Grafana, then update deployment manifests (Helm values, Compose replicas) for persistence.
+5. Scale back down once queue depth drops below 25% of capacity for ten minutes, gracefully draining workers with `celery ... control cancel_consumer` before shutdown.
+
+### Restoring Redis After Outage
+
+1. Confirm Redis is reachable again (`redis-cli ping`).
+2. Flush corrupt broker entries only if necessary; prefer `redis-cli -n 0 keys 'celery*'` to inspect before deletion.
+3. Restart Celery workers to re-establish connections and reload the job cache:
+   ```bash
+   docker compose restart worker
+   ```
+4. Trigger a lightweight synthetic job submission to repopulate cache layers and ensure metrics recover:
+   ```bash
+   curl -X POST http://localhost:8080/jobs \
+     -H "X-Api-Key: $API_KEY" \
+     -H "Content-Type: application/json" \
+     -d '{"input_expression": "1+1", "context": {}}'
+   ```
+5. Monitor `calculator_gateway_job_queue_depth` and `calculator_gateway_jobs_enqueued_total` to verify normal traffic, and clear stale cache entries with `redis-cli -n 0 FLUSHDB` only if data corruption persists.
+
 ## Worker Scaling & Deployment
 
 1. **Horizontal scale-out:** Run multiple Celery worker replicas pinned to the `calculator-jobs` queue. Kubernetes `Deployment` or Docker Compose `scale` can be used; ensure each worker process sets `--hostname` to surface individual heartbeat metrics.
@@ -144,3 +249,23 @@ Mutual TLS is optional—leave `EVALUATOR_CLIENT_CA_PATH` unset to accept TLS wi
 2. Images are tagged `phase1-<sha>` and pushed to a container registry (GHCR or ECR).
 3. CD applies Helm charts or Docker Compose manifests, wiring environment variables and secrets from the deployment target.
 4. Canary deployment gates new versions until metrics and logs stay within SLO thresholds.
+
+## Release Plan – phase2-alpha.1
+
+1. **Pre-flight checks**
+   * Ensure CI green (`make lint`, `make test`, docker image builds) and run the async stack locally with `make compose-up`.
+   * Validate OpenTelemetry traces across enqueue → worker → completion spans in Tempo.
+   * Confirm Grafana's `Gateway Overview` shows live job throughput and queue depth while submitting sample workloads.
+2. **Compose validation**
+   * From a clean checkout run `docker compose -f docker-compose.phase1.yml up --build`.
+   * Submit at least five asynchronous jobs via `/jobs`, ensuring WebSocket notifications broadcast status updates.
+   * Verify Redis queue depth drains and `calculator_gateway_jobs_failed_total` remains 0.
+3. **Tagging & artifacts**
+   * Bump container image tags to `phase2-alpha.1` in deployment manifests.
+   * Create the git tag once validation succeeds: `git tag phase2-alpha.1 && git push origin phase2-alpha.1`.
+4. **Release notes**
+   * Highlight asynchronous job orchestration, Celery/Redis backbone, Prometheus job metrics, Grafana dashboards, and runbook updates.
+   * Document upgrade steps (apply latest migrations, restart gateway and workers, ensure Redis broker at required version).
+5. **Rollout monitoring**
+   * Watch `calculator_gateway_job_queue_depth` and `jobs_in_progress` for 30 minutes post deploy.
+   * Keep an eye on failure counters; revert tag if failure rate >5% or queue depth remains above 80% for 15 minutes.

--- a/observability/grafana/dashboards/gateway-overview.json
+++ b/observability/grafana/dashboards/gateway-overview.json
@@ -221,6 +221,161 @@
       ],
       "title": "Rate-Limit Rejections (5m)",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 16
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(calculator_gateway_jobs_enqueued_total[5m]))",
+          "legendFormat": "Jobs/s",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Async Job Throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.85
+              },
+              {
+                "color": "green",
+                "value": 0.95
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 16
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(calculator_gateway_job_task_runtime_seconds_count{status=\"succeeded\"}[5m])) / sum(rate(calculator_gateway_job_task_runtime_seconds_count[5m]))",
+          "legendFormat": "Success",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Async Job Success Rate (5m)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 16
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "displayMode": "hidden",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(calculator_gateway_job_queue_wait_seconds_sum[5m])) / sum(rate(calculator_gateway_job_queue_wait_seconds_count[5m]))",
+          "legendFormat": "Avg Wait",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Average Queue Wait (5m)",
+      "type": "timeseries"
     }
   ],
   "refresh": "30s",

--- a/services/gateway/app/task_queue.py
+++ b/services/gateway/app/task_queue.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import time
 import datetime as dt
+import re
 from typing import Any, Dict, Mapping, Optional
 
 from celery import Celery
@@ -16,6 +17,8 @@ from opentelemetry.trace import Status, StatusCode
 from redis.asyncio import Redis
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from prometheus_client import Counter, Gauge, Histogram
 
 from services.common.grpc import grpc
 from services.protos import evaluator_pb2, evaluator_pb2_grpc
@@ -37,6 +40,68 @@ task_logger = get_task_logger(__name__)
 tracer = trace.get_tracer(__name__)
 
 settings = get_settings()
+
+_METRIC_NAMESPACE = settings.observability.metrics_namespace
+_JOBS_ENQUEUED = Counter(
+    "jobs_enqueued_total",
+    "Total number of asynchronous calculator jobs submitted.",
+    labelnames=("queue",),
+    namespace=_METRIC_NAMESPACE,
+)
+_JOBS_IN_PROGRESS = Gauge(
+    "jobs_in_progress",
+    "Number of calculator jobs currently being processed by workers.",
+    labelnames=("queue",),
+    namespace=_METRIC_NAMESPACE,
+)
+_JOBS_FAILED = Counter(
+    "jobs_failed_total",
+    "Total number of calculator jobs that ultimately failed.",
+    labelnames=("queue", "reason"),
+    namespace=_METRIC_NAMESPACE,
+)
+_QUEUE_DEPTH = Gauge(
+    "job_queue_depth",
+    "Depth of the Redis-backed Celery queue.",
+    labelnames=("queue",),
+    namespace=_METRIC_NAMESPACE,
+)
+_TASK_RUNTIME = Histogram(
+    "job_task_runtime_seconds",
+    "Histogram of worker execution runtimes by outcome.",
+    labelnames=("queue", "status"),
+    namespace=_METRIC_NAMESPACE,
+    buckets=(
+        0.01,
+        0.05,
+        0.1,
+        0.25,
+        0.5,
+        1.0,
+        2.5,
+        5.0,
+        10.0,
+        30.0,
+    ),
+)
+_QUEUE_WAIT = Histogram(
+    "job_queue_wait_seconds",
+    "Time jobs spend waiting in the queue before worker execution.",
+    labelnames=("queue",),
+    namespace=_METRIC_NAMESPACE,
+    buckets=(
+        0.01,
+        0.05,
+        0.1,
+        0.25,
+        0.5,
+        1.0,
+        2.5,
+        5.0,
+        10.0,
+        30.0,
+    ),
+)
 
 celery_app = Celery("calculator-gateway")
 celery_app.conf.update(
@@ -73,6 +138,8 @@ def enqueue_job(job_id: str, *, trace_context: Optional[Dict[str, str]] = None) 
         kwargs={"trace_context": trace_context or {}},
         queue=settings.job.queue_name,
     )
+    _record_job_enqueued()
+    _schedule_queue_depth_refresh()
 
 
 @celery_app.task(
@@ -119,40 +186,95 @@ async def _execute_job(
             job = await _lock_job(session, job_id)
             if job is None:
                 task_logger.warning("Job %s not found", job_id)
+                await _refresh_queue_depth(redis)
                 return {"status": "missing"}
 
-            with tracer.start_as_current_span("worker.job", attributes={"job.id": job_id}) as span:
-                span.set_attribute("job.attempt", attempt)
-                span.set_attribute("job.max_retries", max_retries)
-                await _mark_running(session, job, cache)
+            _JOBS_IN_PROGRESS.labels(queue=settings.job.queue_name).inc()
+            try:
+                queue_depth_before = await _refresh_queue_depth(redis)
+                with tracer.start_as_current_span(
+                    "worker.job",
+                    attributes={"job.id": job_id, "job.queue_depth_start": queue_depth_before},
+                ) as span:
+                    span.set_attribute("job.attempt", attempt)
+                    span.set_attribute("job.max_retries", max_retries)
+                    queue_wait_ms = _compute_queue_wait_ms(job)
+                    if queue_wait_ms is not None:
+                        span.set_attribute("job.queue_wait_ms", queue_wait_ms)
+                        _QUEUE_WAIT.labels(queue=settings.job.queue_name).observe(queue_wait_ms / 1000.0)
 
-                try:
-                    response = await _invoke_evaluator(job, trace_headers)
-                except grpc.RpcError as exc:
-                    return await _handle_grpc_failure(
-                        session,
-                        job,
-                        cache,
-                        exc,
-                        attempt=attempt,
-                        max_retries=max_retries,
-                    )
-                except Exception as exc:  # noqa: BLE001
-                    await _mark_failed(session, job, cache, str(exc))
-                    raise JobExecutionError(str(exc)) from exc
+                    await _mark_running(session, job, cache)
 
-                result_payload = _build_result_payload(response)
-                status = STATUS_SUCCEEDED if result_payload.get("value") is not None else STATUS_FAILED
-                await _finalize_job(session, job, cache, status=status, payload=result_payload)
-                span.set_attribute("job.status", status)
-                span.set_status(Status(StatusCode.OK))
-                duration_ms = (time.perf_counter() - start_time) * 1000.0
-                span.set_attribute("job.duration_ms", duration_ms)
-                return {
-                    "status": status,
-                    "result": result_payload,
-                    "duration_ms": duration_ms,
-                }
+                    try:
+                        response = await _invoke_evaluator(job, trace_headers)
+                        result_payload = _build_result_payload(response)
+                        status = (
+                            STATUS_SUCCEEDED
+                            if result_payload.get("value") is not None
+                            else STATUS_FAILED
+                        )
+                        await _finalize_job(session, job, cache, status=status, payload=result_payload)
+                        span.set_attribute("job.status", status)
+                        span.set_status(Status(StatusCode.OK))
+                        duration_ms = (time.perf_counter() - start_time) * 1000.0
+                        span.set_attribute("job.duration_ms", duration_ms)
+                        if status == STATUS_FAILED:
+                            _record_job_failure(result_payload.get("error") or "evaluator_error")
+                        queue_depth_after = await _refresh_queue_depth(redis)
+                        span.set_attribute("job.queue_depth_end", queue_depth_after)
+                        _observe_task_runtime(status, duration_ms)
+                        return {
+                            "status": status,
+                            "result": result_payload,
+                            "duration_ms": duration_ms,
+                        }
+                    except grpc.RpcError as exc:
+                        try:
+                            return await _handle_grpc_failure(
+                                session,
+                                job,
+                                cache,
+                                exc,
+                                attempt=attempt,
+                                max_retries=max_retries,
+                            )
+                        finally:
+                            queue_depth_after = await _refresh_queue_depth(redis)
+                            span.set_attribute("job.queue_depth_end", queue_depth_after)
+                    except TransientJobError as exc:
+                        duration_ms = (time.perf_counter() - start_time) * 1000.0
+                        span.set_attribute("job.status", STATUS_QUEUED)
+                        span.set_attribute("job.duration_ms", duration_ms)
+                        span.record_exception(exc)
+                        span.set_status(Status(StatusCode.ERROR))
+                        queue_depth_after = await _refresh_queue_depth(redis)
+                        span.set_attribute("job.queue_depth_end", queue_depth_after)
+                        raise
+                    except JobExecutionError as exc:
+                        duration_ms = (time.perf_counter() - start_time) * 1000.0
+                        span.set_attribute("job.status", STATUS_FAILED)
+                        span.set_attribute("job.duration_ms", duration_ms)
+                        span.record_exception(exc)
+                        span.set_status(Status(StatusCode.ERROR))
+                        queue_depth_after = await _refresh_queue_depth(redis)
+                        span.set_attribute("job.queue_depth_end", queue_depth_after)
+                        _record_job_failure(exc)
+                        _observe_task_runtime(STATUS_FAILED, duration_ms)
+                        raise
+                    except Exception as exc:  # noqa: BLE001
+                        duration_ms = (time.perf_counter() - start_time) * 1000.0
+                        span.set_attribute("job.status", STATUS_FAILED)
+                        span.set_attribute("job.duration_ms", duration_ms)
+                        span.record_exception(exc)
+                        span.set_status(Status(StatusCode.ERROR))
+                        queue_depth_after = await _refresh_queue_depth(redis)
+                        span.set_attribute("job.queue_depth_end", queue_depth_after)
+                        _record_job_failure(exc)
+                        _observe_task_runtime(STATUS_FAILED, duration_ms)
+                        await _mark_failed(session, job, cache, str(exc))
+                        raise JobExecutionError(str(exc)) from exc
+            finally:
+                _JOBS_IN_PROGRESS.labels(queue=settings.job.queue_name).dec()
     finally:
         await redis.close()
 
@@ -266,4 +388,81 @@ def _get_sync_stub() -> evaluator_pb2_grpc.EvaluatorStub:
         _sync_channel = create_sync_channel(settings.evaluator)
         _sync_stub = evaluator_pb2_grpc.EvaluatorStub(_sync_channel)
     return _sync_stub
+
+
+def _record_job_enqueued() -> None:
+    _JOBS_ENQUEUED.labels(queue=settings.job.queue_name).inc()
+
+
+def _observe_task_runtime(status: str, duration_ms: float) -> None:
+    _TASK_RUNTIME.labels(queue=settings.job.queue_name, status=status).observe(duration_ms / 1000.0)
+
+
+def _record_job_failure(reason: Exception | str) -> None:
+    label = _normalize_failure_reason(reason)
+    _JOBS_FAILED.labels(queue=settings.job.queue_name, reason=label).inc()
+
+
+def _normalize_failure_reason(reason: Exception | str) -> str:
+    if isinstance(reason, Exception):
+        detail = str(reason).strip()
+        if detail:
+            text = detail
+        else:
+            text = reason.__class__.__name__
+    else:
+        text = str(reason).strip()
+    if not text:
+        text = "unknown"
+    sanitized = text.lower().replace(" ", "_")
+    sanitized = re.sub(r"[^a-z0-9_\-\.]+", "_", sanitized)
+    sanitized = sanitized.strip("_") or "unknown"
+    return sanitized[:64]
+
+
+def _compute_queue_wait_ms(job: Job) -> Optional[float]:
+    created_at = job.created_at
+    if not created_at:
+        return None
+    if created_at.tzinfo is None:
+        created_at = created_at.replace(tzinfo=dt.timezone.utc)
+    now = dt.datetime.now(dt.timezone.utc)
+    wait_seconds = max((now - created_at).total_seconds(), 0.0)
+    return wait_seconds * 1000.0
+
+
+async def _refresh_queue_depth(redis: Redis) -> int:
+    if not hasattr(redis, "llen"):
+        return 0
+    queue_name = settings.job.queue_name
+    keys_to_check = [f"queue:{queue_name}", queue_name, f"{queue_name}-applied"]
+    depth = 0
+    for key in keys_to_check:
+        try:
+            value = await redis.llen(key)
+        except Exception:  # noqa: BLE001
+            continue
+        if value:
+            depth = int(value)
+            break
+    _QUEUE_DEPTH.labels(queue=queue_name).set(depth)
+    return depth
+
+
+def _schedule_queue_depth_refresh() -> None:
+    async def _update() -> None:
+        redis = Redis.from_url(settings.redis.url, decode_responses=True)
+        try:
+            await _refresh_queue_depth(redis)
+        except Exception as exc:  # noqa: BLE001
+            task_logger.debug("Queue depth refresh failed: %s", exc)
+        finally:
+            await redis.close()
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        asyncio.run(_update())
+    else:
+        loop.create_task(_update())
 

--- a/services/gateway/tests/test_jobs_logic.py
+++ b/services/gateway/tests/test_jobs_logic.py
@@ -35,6 +35,10 @@ class _RecordingRedis:
         self.storage.pop(key, None)
         self.events.append(("delete", key, None))
 
+    async def llen(self, key: str) -> int:
+        self.events.append(("llen", key, None))
+        return 0
+
     async def close(self) -> None:  # pragma: no cover - provided for API parity
         return None
 


### PR DESCRIPTION
## Summary
- extend the gateway Celery task queue with OpenTelemetry span attributes and Prometheus metrics for enqueues, in-progress jobs, failures, queue depth, runtime, and queue wait time
- refresh Grafana's Gateway Overview dashboard and documentation (OPERATIONS, CALCULATOR_USAGE) with asynchronous job guidance, runbooks, and a release plan alongside a new ADR covering the Celery/Redis queue decision

## Testing
- make test
- poetry -C services/gateway run pytest *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_68e10cf67628832d892d725d6697ddbd