### PR TITLE
Fix async job docs and ensure tests execute

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,45 +1,68 @@
-# Phase 1 Architecture Overview
+# Phase 2 Architecture Overview
+
+Phase 2 extends the synchronous calculator into a distributed job platform. The FastAPI gateway now orchestrates Celery workers,
+persists job state, and broadcasts live updates over WebSockets while preserving the hardened Phase 1 core.
 
 ## Service Topology
 
 ```
-+------------+      +-----------------+      +--------------------+
-|  Clients   | ---> |  Gateway (API)  | ---> | Safe Evaluator RPC |
-+------------+      +-----------------+      +--------------------+
-        |                    |                         |
-        |                    v                         v
-        |              Redis (Rate)                Sandbox Runner
-        |                    |
-        v                    v
- Prometheus / Tempo / Loki  Postgres (Keys, Audit)
++------------+       +----------------------+       +----------------------+       +--------------------+
+|  Clients   |  ---> |  Gateway (FastAPI)   |  ---> |   Redis (Broker &    |  ---> |  Celery Workers    |
+| (REST/WS)  |       |  + Task Orchestrator |       |   Job Cache)         |       |  (Evaluator Tasks) |
++------------+       +----------------------+       +----------------------+       +--------------------+
+        |                        |                            |                           |
+        |                        |                            v                           |
+        |                        |                      Postgres (Jobs, API Keys, Audit)  |
+        |                        |                                                        |
+        v                        v                                                        v
+ Prometheus / Tempo / Loki  WebSocket Hub (in Gateway)                               Safe Evaluator gRPC
 ```
 
-* **Gateway (FastAPI)** – hosts `/calculate-sync`, `/calculate`, health endpoints, and metrics. Handles authentication, rate limiting, caching, audit logging, and gRPC calls to the evaluator.
-* **Safe Evaluator (gRPC)** – executes expressions in a subprocess sandbox, enforcing AST validation, runtime limits, and result magnitude caps.
-* **Shared Infrastructure** – Redis provides both a cache and per-tenant sliding window limits. Postgres persists API keys, audit logs, and quota metadata. The observability stack collects traces, metrics, and logs via OTLP exporters.
+* **Gateway (FastAPI)** – exposes REST endpoints for synchronous calculations and asynchronous job submission (`/jobs`), WebSocket
+  feeds (`/ws/jobs/{id}`), job metadata views, and operational health probes. It validates API keys, enforces rate & quota limits,
+  writes job headers to Postgres, and seeds Redis caches before delegating work to Celery.
+* **Task Orchestrator (Celery)** – embedded in the gateway package. Jobs are enqueued onto Redis-backed queues with priority lanes
+  derived from `JobSettings.priority_levels`. Celery workers claim tasks, manage retries, and report lifecycle events back into the
+  cache/pub-sub fabric.
+* **Worker Pool** – one or more worker processes execute calculator/evaluator RPCs. They stream status transitions via Redis pub/sub
+  so WebSocket clients receive near-real-time updates and metrics capture queue depth and latency.
+* **Result Store & Metadata** – Postgres persists authoritative job rows (id, status, attempts, payload hashes) while Redis caches the
+  serialized response envelopes with a TTL for fast repeat lookups.
+* **Notification Layer** – The gateway-hosted WebSocket hub subscribes to per-job Redis channels and pushes updates to authenticated
+  clients, falling back to HTTP polling if the socket closes.
+* **Observability Stack** – Prometheus, Grafana, Tempo, and Loki surface queue depth, worker throughput, and end-to-end traces that span
+  enqueue → worker execution → completion.
 
-## Request Flow
+## Asynchronous Job Flow
 
-1. Client submits expression with `X-Api-Key` header.
-2. Gateway validates key against Postgres and enforces Redis-based rate limits.
-3. Gateway checks Redis cache for deterministic results.
-4. Gateway invokes the safe evaluator over the `/evaluator.v1.Evaluator/Evaluate` RPC with a 250 ms deadline.
-5. Safe evaluator validates AST, enforces complexity budget, and runs the expression inside a subprocess sandbox.
-6. Result is returned to the gateway, cached (optional), and written to the audit log asynchronously.
+1. Client submits a job to `/jobs` with an API key, payload, and optional priority/tags.
+2. Gateway enforces quota/rate policies, persists a `queued` job row, writes the serialized payload into Redis, and publishes an initial
+   update on the job’s notification channel.
+3. `enqueue_job` hands the identifier to Celery with OpenTelemetry trace headers; `_record_job_enqueued` updates metrics.
+4. A Celery worker locks the row, transitions the job to `running`, and invokes the evaluator gRPC service. Intermediate states are cached
+   and published for WebSocket consumers.
+5. On success, the worker finalizes the row with the resulting payload (`succeeded`). Failures capture the error string and leverage Celery’s
+   retry/backoff facilities for transient issues.
+6. Clients receive updates either by polling `/jobs/{id}` (served from Redis/Postgres) or maintaining an authenticated WebSocket subscription
+   to `/ws/jobs/{id}`.
 
 ## Configuration Layers
 
-* `.env.development`, `.env.test`, `.env.production` – environment-specific overrides consumed by `pydantic-settings` classes in each service.
-* Alembic maintains schema migrations for Postgres. The initial revision provisions `api_keys`, `request_audit`, and `quotas` tables.
+* Environment files (`.env.development`, `.env.test`, `.env.production`) hydrate `GatewaySettings`, covering Redis brokers, priority levels,
+  retry policies, and notification namespaces.
+* Alembic migrations manage the Postgres schema (API keys, request audit, quotas, jobs). Redis requires no migrations but expects consistent
+  namespace configuration between cache and pub/sub consumers.
 
 ## Observability
 
-* OpenTelemetry SDK exports spans to Tempo (OTLP HTTP) and falls back to console output when no collector is configured.
-* `prometheus_fastapi_instrumentator` exposes gateway metrics at `/metrics`; the evaluator can be scraped through OTLP exporters.
-* Loki/Promtail ingest JSON-structured logs from both containers for centralized dashboards.
+* OpenTelemetry traces span enqueue to worker completion, including evaluator RPC spans and queue depth annotations.
+* Prometheus metrics (e.g., `calculator_gateway_job_queue_depth`, `calculator_gateway_job_task_runtime_seconds`) power Grafana dashboards for
+  throughput, latency, and worker health. WebSocket connection counts are exported via FastAPI instrumentation.
+* Loki and Tempo continue to ingest structured logs and traces from gateway and worker containers for incident correlation.
 
 ## Network Layout
 
-* All services share the `calc-platform-net` Docker bridge network defined in `docker-compose.phase1.yml`.
-* Gateway exposes port `8080` publicly. Safe evaluator remains internal on `50051`.
-* OTLP, Prometheus, and Grafana ports are accessible locally for diagnostics.
+* All services share the `calc-platform-net` Docker bridge network (or equivalent Kubernetes namespace). Gateway exposes port `8080` for REST
+  and WebSocket traffic; Celery workers and the evaluator communicate over internal networks and gRPC port `50051`.
+* Redis (broker/cache) and Postgres remain internal services. Observability endpoints (Prometheus, Grafana, Tempo) are locally exposed for
+  diagnostics and load testing coordination.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -179,6 +179,14 @@ Mutual TLS is optional—leave `EVALUATOR_CLIENT_CA_PATH` unset to accept TLS wi
    ```
 5. Track recovery on Grafana (`Gateway Overview → Async Job Throughput`) and via the `calculator_gateway_job_queue_depth` gauge.
 
+### WebSocket Notification Channel
+
+1. Authenticate by passing `X-Api-Key` during the WebSocket handshake. The gateway reuses the REST dependency, so local overrides from tests (e.g., dependency injection) also apply.
+2. On connect the gateway replays the cached payload (from Redis or Postgres) before streaming incremental updates published by workers. Expect the first frame to contain `status="queued"` along with polling links.
+3. Redis pub/sub channels follow `JobSettings.notification_namespace`. If notifications stall, inspect `redis-cli pubsub channels job_events:*` to confirm messages are flowing. Then verify Celery workers are still consuming the calculator queue with `celery -A services.gateway.app.task_queue inspect active_queues --destination=worker@%h`; restart any missing workers so they re-subscribe to Redis notifications.
+4. Clients should treat WebSocket disconnects as transient. Reconnect with exponential backoff and fall back to `GET /jobs/{id}` until the socket stabilizes.
+5. To smoke-test end to end, run `wscat -c ws://localhost:8080/ws/jobs/<id> -H "X-Api-Key: $API_KEY"` while submitting new jobs; observe `queued → running → succeeded` frames within a few hundred milliseconds of worker transitions.
+
 ### Clearing Failed Queue
 
 1. Quantify failures and reasons:
@@ -232,7 +240,16 @@ Mutual TLS is optional—leave `EVALUATOR_CLIENT_CA_PATH` unset to accept TLS wi
 ## Worker Scaling & Deployment
 
 1. **Horizontal scale-out:** Run multiple Celery worker replicas pinned to the `calculator-jobs` queue. Kubernetes `Deployment` or Docker Compose `scale` can be used; ensure each worker process sets `--hostname` to surface individual heartbeat metrics.
-2. **Priority lanes:** Enable tiered QoS by configuring Celery routing keys per priority level. The gateway maps the `priority` field into discrete buckets (`JobSettings.priority_levels`); provision dedicated queues (e.g., `calculator-jobs.high`, `calculator-jobs.normal`) and route via Celery's `task_routes` to guarantee latency for critical jobs.
+2. **Priority lanes:** Enable tiered QoS by configuring Celery routing keys per priority level. The gateway maps the `priority` field into discrete buckets (`JobSettings.priority_levels`); provision dedicated queues (e.g., `calculator-jobs.high`, `calculator-jobs.normal`) and route via Celery's `task_routes` to guarantee latency for critical jobs. A minimal router looks like:
+   ```python
+   celery_app.conf.task_routes = {
+       "gateway.execute_job": {
+           "queue": "calculator-jobs.high",
+           "routing_key": "calculator.jobs.high",
+       }
+   }
+   ```
+   Run latency-sensitive workers with `celery worker --queues calculator-jobs.high` and background pools against the default queue to prevent starvation.
 3. **Autoscaling guidance:** Monitor the `gateway.job.queue_depth` Prometheus metric and Celery worker heartbeats. Trigger scale-up when queue depth exceeds 75% of `JobSettings.max_queue_size` or worker CPU saturates >80% for five minutes. Scale-down once backlog clears and concurrency utilization drops below 40%.
 4. **Stateful persistence:** Postgres holds the job ledger (`jobs` table) while Redis caches in-flight/completed payloads with TTL. During deployments, drain workers gracefully (`celery -A app.task_queue control cancel_consumer`) before terminating pods to avoid losing locks on running jobs.
 5. **Disaster recovery:** Restore Postgres from point-in-time backups to recover job metadata; expired Redis entries are rehydrated from the database on demand. Document fallback procedures to manually requeue jobs via `enqueue_job` if necessary.

--- a/services/gateway/pyproject.toml
+++ b/services/gateway/pyproject.toml
@@ -38,3 +38,8 @@ respx = "^0.21.1"
 ruff = "^0.6.0"
 pytest-cov = "^5.0.0"
 locust = "^2.20.1"
+
+[tool.pytest.ini_options]
+markers = [
+    "asyncio: mark test to run inside an event loop",
+]

--- a/services/gateway/tests/test_jobs_logic.py
+++ b/services/gateway/tests/test_jobs_logic.py
@@ -6,6 +6,8 @@ import pytest_asyncio
 from celery.result import EagerResult
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
+pytest_plugins = ("pytest_asyncio.plugin",)
+
 from services.gateway.app import jobs, task_queue
 from services.gateway.app.config import GatewaySettings
 from services.gateway.app.models import Base
@@ -172,4 +174,15 @@ async def test_celery_job_lifecycle_in_eager_mode(
         result_payload = refreshed.result_payload
 
     assert result_payload["value"] == 42.0
+
+
+@pytest.mark.asyncio
+async def test_publish_job_update_emits_json(test_settings: GatewaySettings) -> None:
+    redis = _RecordingRedis()
+    payload = {"id": "job-123", "status": jobs.STATUS_RUNNING}
+
+    await jobs.publish_job_update(redis, "job-123", payload, settings=test_settings)
+
+    expected_channel = jobs.build_job_channel(test_settings, "job-123")
+    assert ("publish", expected_channel, json.dumps(payload)) in redis.events
 

--- a/tests/load/locustfile.py
+++ b/tests/load/locustfile.py
@@ -1,8 +1,46 @@
 """Locust load test hitting the asynchronous job submission APIs."""
 
+from __future__ import annotations
+
 from collections import deque
+import time
 
 from locust import HttpUser, between, events, task
+
+
+def _extract_metric_value(
+    metrics_text: str,
+    metric_name: str,
+    label_filter: dict[str, str] | str | None = None,
+) -> float | None:
+    for line in metrics_text.splitlines():
+        if not line or line.startswith("#"):
+            continue
+        if not line.startswith(metric_name):
+            continue
+        if label_filter:
+            if isinstance(label_filter, dict):
+                if any(f'{key}="{value}"' not in line for key, value in label_filter.items()):
+                    continue
+            elif label_filter not in line:
+                continue
+        try:
+            return float(line.rsplit(" ", 1)[-1])
+        except ValueError:
+            continue
+    return None
+
+
+def _extract_histogram_average(
+    metrics_text: str,
+    metric_name: str,
+    label_filter: dict[str, str] | str | None = None,
+) -> float | None:
+    total = _extract_metric_value(metrics_text, f"{metric_name}_sum", label_filter)
+    count = _extract_metric_value(metrics_text, f"{metric_name}_count", label_filter)
+    if total is None or count is None or count == 0:
+        return None
+    return (total / count) * 1000.0
 
 
 class JobUser(HttpUser):
@@ -11,6 +49,7 @@ class JobUser(HttpUser):
     def on_start(self):
         self.api_key = self.environment.parsed_options.api_key
         self.recent_jobs: deque[str] = deque(maxlen=100)
+        self._next_metrics_sample = 0.0
 
     @task(3)
     def submit_job(self):
@@ -39,6 +78,45 @@ class JobUser(HttpUser):
         job_id = self.recent_jobs[0]
         headers = {"X-Api-Key": self.api_key}
         self.client.get(f"/jobs/{job_id}", headers=headers, name="/jobs/{id}")
+
+    @task
+    def sample_metrics(self):
+        now = time.time()
+        if now < self._next_metrics_sample:
+            return
+        self._next_metrics_sample = now + 5.0
+
+        with self.client.get("/metrics", name="/metrics (sample)", catch_response=True) as response:
+            if response.status_code != 200:
+                response.failure(f"Metrics scrape failed: {response.status_code}")
+                return
+            metrics_text = response.text
+
+        queue_depth = _extract_metric_value(
+            metrics_text,
+            "calculator_gateway_job_queue_depth",
+            {"queue": "calculator-jobs"},
+        )
+        if queue_depth is not None:
+            events.request_success.fire(
+                request_type="GAUGE",
+                name="queue_depth",
+                response_time=queue_depth,
+                response_length=0,
+            )
+
+        runtime_avg_ms = _extract_histogram_average(
+            metrics_text,
+            "calculator_gateway_job_task_runtime_seconds",
+            {"queue": "calculator-jobs", "status": "succeeded"},
+        )
+        if runtime_avg_ms is not None:
+            events.request_success.fire(
+                request_type="GAUGE",
+                name="worker_runtime_ms",
+                response_time=runtime_avg_ms,
+                response_length=0,
+            )
 
 
 @events.init_command_line_parser.add_listener


### PR DESCRIPTION
## Summary
- correct the WebSocket notification runbook to point operators at the proper Celery queue inspection flow
- force pytest to load the bundled pytest-asyncio plugin so coroutine tests execute instead of skipping
- register the asyncio marker in pytest configuration to eliminate collection warnings

## Testing
- PYTHONPATH=. pytest services/gateway/tests/test_jobs_logic.py

------
https://chatgpt.com/codex/tasks/task_e_68e210afe9a8832db7c88ed9c0a9ddc0