### PR TITLE
Observability & Runbooks: Phase-2 async metrics, spans, dashboards, runbooks, ADR, release plan

### DIFF
--- a/services/gateway/app/task_queue.py
+++ b/services/gateway/app/task_queue.py
@@ -352,7 +352,6 @@ async def _handle_grpc_failure(
         raise TransientJobError(detail) from exc
 
     await _mark_failed(session, job, cache, redis, detail)
-    _WORKER_METRICS.jobs_failed.labels(queue=queue_name, task=_TASK_NAME).inc()
     raise JobExecutionError(detail) from exc
 
 

--- a/services/gateway/app/task_queue.py
+++ b/services/gateway/app/task_queue.py
@@ -253,7 +253,7 @@ async def _execute_job(
 
                     span.set_attribute("job.status", status)
                     if status == STATUS_FAILED:
-                        _WORKER_METRICS.jobs_failed.labels(queue=queue_name, task=_TASK_NAME).inc()
+                        span.set_attribute("outcome", "failed")
                     return {
                         "status": status,
                         "result": result_payload,
@@ -275,7 +275,6 @@ async def _execute_job(
                 except JobExecutionError:
                     raise
                 except Exception as exc:  # noqa: BLE001
-                    _WORKER_METRICS.jobs_failed.labels(queue=queue_name, task=_TASK_NAME).inc()
                     await _mark_failed(session, job, cache, redis, str(exc))
                     raise JobExecutionError(str(exc)) from exc
     finally:

--- a/src/worker/instrumentation.py
+++ b/src/worker/instrumentation.py
@@ -89,14 +89,18 @@ def worker_task_span(
             span.record_exception(exc)
             span.set_status(Status(StatusCode.ERROR))
             span.set_attribute("outcome", outcome)
-            metrics.jobs_failed.labels(queue=queue, task=task).inc()
             raise
         else:
-            outcome = "success"
-            span.set_status(Status(StatusCode.OK))
-            span.set_attribute("outcome", outcome)
+            explicit_outcome = getattr(span, "attributes", {}).get("outcome")
+            outcome = str(explicit_outcome) if explicit_outcome else "success"
+            if not explicit_outcome:
+                span.set_attribute("outcome", outcome)
+            span.set_status(Status(StatusCode.OK) if outcome == "success" else Status(StatusCode.ERROR))
         finally:
             worker_process_ms = (time.perf_counter() - start_time) * 1000.0
             span.set_attribute("worker_process_ms", worker_process_ms)
             metrics.celery_task_runtime_seconds.labels(task=task).observe(worker_process_ms / 1000.0)
             metrics.jobs_in_progress.labels(queue=queue, task=task).dec()
+            final_outcome = getattr(span, "attributes", {}).get("outcome", outcome)
+            if final_outcome == "failed":
+                metrics.jobs_failed.labels(queue=queue, task=task).inc()

--- a/tests/metrics/test_prometheus_export.py
+++ b/tests/metrics/test_prometheus_export.py
@@ -1,11 +1,14 @@
 from prometheus_client import REGISTRY, generate_latest
 
+from src.notifications import notifications as notification_metrics
 from src.observability.metrics import get_job_metrics
 
 
 def test_metric_collectors_registered() -> None:
     # Ensure metrics are initialised
     get_job_metrics(None)
+    notification_metrics.ws_client_connected("/test")
+    notification_metrics.ws_client_disconnected("/test")
 
     body = generate_latest(REGISTRY).decode("utf-8")
     for expected in (

--- a/tests/observability/test_spans_job_flow.py
+++ b/tests/observability/test_spans_job_flow.py
@@ -5,6 +5,18 @@ from src.observability.metrics import get_job_metrics
 from src.worker.instrumentation import worker_task_span
 
 
+def _counter_value(metric, **labels) -> float:
+    child = metric.labels(**labels)
+    child.inc(0)
+    sample = next(
+        sample
+        for collector in metric.collect()
+        for sample in collector.samples
+        if all(sample.labels.get(k) == v for k, v in labels.items())
+    )
+    return sample.value
+
+
 def test_enqueue_and_worker_spans_include_expected_attributes() -> None:
     job_id = "abcd1234efgh5678"
     queue = "calculator"
@@ -16,6 +28,7 @@ def test_enqueue_and_worker_spans_include_expected_attributes() -> None:
     metrics = get_job_metrics(None)
     headers = {"x-enqueued-at-ms": str(int((time.time() - 0.05) * 1000))}
 
+    metrics.jobs_in_progress.labels(queue=queue, task=task).inc()
     with worker_task_span(job_id, queue, task, headers, metrics) as worker_span:
         time.sleep(0.01)
 
@@ -30,3 +43,19 @@ def test_enqueue_and_worker_spans_include_expected_attributes() -> None:
     assert worker_span.attributes["worker_process_ms"] >= 0.0
     worker_events = {name: attrs for name, attrs in worker_span.events}
     assert worker_events["job.id"]["job_id"] == job_id
+
+
+def test_worker_span_failed_outcome_increments_metrics() -> None:
+    job_id = "ffcc0011aaee7788"
+    queue = "calculator"
+    task = "gateway.execute_job"
+    metrics = get_job_metrics(None)
+    headers = {"x-enqueued-at-ms": str(int(time.time() * 1000))}
+
+    before = _counter_value(metrics.jobs_failed, queue=queue, task=task)
+    metrics.jobs_in_progress.labels(queue=queue, task=task).inc()
+    with worker_task_span(job_id, queue, task, headers, metrics) as span:
+        span.set_attribute("outcome", "failed")
+
+    after = _counter_value(metrics.jobs_failed, queue=queue, task=task)
+    assert after == before + 1


### PR DESCRIPTION
## Summary
- prevent double-counting failed jobs by letting the worker span own the final outcome and metrics emission, keeping Grafana’s calculator-phase2 dashboard panels accurate (`grafana/dashboards/calculator-phase2.json`)
- flag failed outcomes on the task span when persistence detects a terminal error so the `jobs_failed{queue,task}` counter reflects real job results surfaced in the runbooks (`docs/runbooks/jobs_stuck.md`, `docs/runbooks/queue_recovery.md`)
- extend the observability test suite to assert the worker span failure path and the shared Prometheus registry export (`tests/observability/test_spans_job_flow.py`, `tests/metrics/test_prometheus_export.py`)

## Testing
- `pytest`

## Runbooks & Dashboards
- Runbooks: docs/runbooks/websocket_notifications.md, docs/runbooks/jobs_stuck.md, docs/runbooks/queue_recovery.md, docs/runbooks/redis_restore.md
- Dashboard: grafana/dashboards/calculator-phase2.json

------
https://chatgpt.com/codex/tasks/task_e_68e21c927a24832d81a79634ba81723c