### PR TITLE
Observability Baseline: ASGI /metrics installer, gateway wiring, worker signal metrics + tests

### DIFF
--- a/.github/workflows/obs-smoke.yml
+++ b/.github/workflows/obs-smoke.yml
@@ -1,0 +1,32 @@
+name: Observability Smoke
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - develop
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        shell: bash
+        run: |
+          set -euxo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install poetry
+          if [ -f pyproject.toml ]; then
+            poetry export -f requirements.txt --without-hashes -o /tmp/req.txt || true
+            poetry export -f requirements.txt --with dev --without-hashes -o /tmp/dev-req.txt || true
+          fi
+          python -m pip install -r /tmp/req.txt 2>/dev/null || true
+          python -m pip install -r /tmp/dev-req.txt 2>/dev/null || true
+          python -m pip install pytest starlette fastapi prometheus_client
+      - name: Quick Check
+        run: python scripts/verify_observability.py

--- a/Makefile
+++ b/Makefile
@@ -24,3 +24,11 @@ compose-up:
 
 compose-down:
 	docker compose -f docker-compose.phase1.yml down
+
+.PHONY: quick-check
+quick-check:
+	@python scripts/verify_observability.py
+
+.PHONY: quick-tests
+quick-tests:
+	@poetry run pytest -q tests/metrics/test_metrics_endpoint.py tests/metrics/test_worker_signals.py

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,16 @@
 # Release Notes
 
+## Unreleased
+
+### Observability
+
+- Added reusable helpers to expose Prometheus `/metrics` endpoints across gateway and worker processes, ensuring idempotent registration backed by the shared registry.
+- Wired Celery worker signal hooks for tracing spans, queue wait histograms, and failure counters; provided a lightweight FastAPI metrics app for workers.
+- Extended tests covering Prometheus exposure, queue instrumentation, and Celery signal lifecycles to guard the observability baseline.
+- NEW: `install_prometheus_endpoint` for any ASGI app; idempotent, shared registry.
+- Gateway: `/metrics` via the shared installer; enqueue header `x-enqueued-at-ms` for queue-wait tracing.
+- Worker: Celery signal instrumentation with bounded-cardinality labels and a standalone FastAPI metrics app.
+
 ## phase2-alpha.1
 
 ### Highlights

--- a/prometheus_client/__init__.py
+++ b/prometheus_client/__init__.py
@@ -108,13 +108,22 @@ class _Registry:
     def __init__(self) -> None:
         self._names_to_collectors: Dict[str, _Collector] = {}
 
+    def collect(self):  # pragma: no cover - compatibility shim
+        return self._names_to_collectors.values()
+
+
+class CollectorRegistry(_Registry):
+    """Minimal CollectorRegistry implementation for local tests."""
+
+    pass
+
 
 REGISTRY = _Registry()
 
 
 def generate_latest(registry: _Registry = REGISTRY) -> bytes:
     lines: list[str] = []
-    for collector in registry._names_to_collectors.values():
+    for collector in registry.collect():
         lines.append(f"# HELP {collector.name} {collector.documentation}")
         metric_type = "counter"
         if isinstance(collector, Gauge):
@@ -132,4 +141,11 @@ def generate_latest(registry: _Registry = REGISTRY) -> bytes:
     return ("\n".join(lines) + "\n").encode("utf-8")
 
 
-__all__ = ["Counter", "Gauge", "Histogram", "REGISTRY", "generate_latest"]
+__all__ = [
+    "CollectorRegistry",
+    "Counter",
+    "Gauge",
+    "Histogram",
+    "REGISTRY",
+    "generate_latest",
+]

--- a/scripts/verify_observability.py
+++ b/scripts/verify_observability.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Lightweight offline checks for the observability baseline."""
+from __future__ import annotations
+
+import asyncio
+import inspect
+import sys
+from pathlib import Path
+from typing import List, Tuple
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+try:  # pragma: no cover - import guard for thin environments
+    from fastapi import FastAPI
+except Exception as exc:  # pragma: no cover - surfaced in script output
+    FastAPI = None  # type: ignore[assignment]
+    _IMPORT_ERROR = exc
+else:
+    _IMPORT_ERROR = None
+
+PROM_CONTENT_TYPE = "text/plain; version=0.0.4"
+
+
+def _prepare_import_path() -> None:
+    """Ensure the repository's ``src`` layout is importable."""
+    src_path = ROOT / "src"
+    if src_path.exists() and str(src_path) not in sys.path:
+        sys.path.insert(0, str(src_path))
+
+
+def _invoke_metrics(app: FastAPI, path: str) -> Tuple[int, str]:
+    """Call the metrics endpoint directly to obtain status and content type."""
+    routes = list(getattr(app, "routes", []) or [])
+    router = getattr(app, "router", None)
+    if router is not None:
+        routes.extend(getattr(router, "routes", []) or [])
+
+    for route in routes:
+        route_path = getattr(route, "path", getattr(route, "path_format", None))
+        if route_path != path:
+            if isinstance(route, tuple) and route[0] == path:
+                handler = route[1]
+            else:
+                continue
+        else:
+            handler = getattr(route, "endpoint", getattr(route, "app", None))
+        if handler is None:
+            continue
+        result = handler()
+        if inspect.isawaitable(result):
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:  # pragma: no cover - fallback for sync contexts
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
+            result = loop.run_until_complete(result)  # pragma: no cover
+        status = getattr(result, "status_code", 200)
+        media_type = getattr(result, "media_type", "") or getattr(result, "headers", {}).get(
+            "content-type", ""
+        )
+        if media_type:
+            return status, media_type
+        headers = getattr(result, "headers", {})
+        return status, headers.get("content-type", "")
+    raise RuntimeError(f"metrics endpoint {path} not found")
+
+
+def check_gateway_installer() -> Tuple[str, bool, str]:
+    if FastAPI is None:
+        return ("gateway_metrics", False, f"dependencies unavailable: {_IMPORT_ERROR!r}")
+
+    _prepare_import_path()
+    try:
+        from src.observability.prom_installer import install_prometheus_endpoint
+    except Exception as exc:  # pragma: no cover - surfaced via script output
+        return ("gateway_installer_import", False, repr(exc))
+
+    app = FastAPI()
+    install_prometheus_endpoint(app)
+    install_prometheus_endpoint(app)
+
+    status, media_type = _invoke_metrics(app, "/metrics")
+    ok = status == 200 and PROM_CONTENT_TYPE in media_type
+    return ("gateway_metrics", ok, media_type)
+
+
+def check_worker_metrics_app() -> Tuple[str, bool, str]:
+    if FastAPI is None:
+        return ("worker_metrics", False, f"dependencies unavailable: {_IMPORT_ERROR!r}")
+
+    _prepare_import_path()
+    try:
+        from worker.metrics_app import app
+    except Exception as exc:  # pragma: no cover - surfaced via script output
+        return ("worker_metrics_import", False, repr(exc))
+
+    status, media_type = _invoke_metrics(app, "/metrics")
+    ok = status == 200 and PROM_CONTENT_TYPE in media_type
+    return ("worker_metrics", ok, media_type)
+
+
+def run_worker_signals_pytest() -> Tuple[str, bool, str]:
+    try:
+        import pytest
+    except Exception as exc:  # pragma: no cover - surfaced via script output
+        return ("worker_signals_pytest", False, f"pytest unavailable: {exc!r}")
+
+    result = pytest.main(["-q", "tests/metrics/test_worker_signals.py"])
+    return ("worker_signals_pytest", result == 0, f"exit_code={result}")
+
+
+def main(argv: List[str] | None = None) -> int:
+    _ = argv  # unused but keeps signature flexible
+    checks = [
+        check_gateway_installer(),
+        check_worker_metrics_app(),
+        run_worker_signals_pytest(),
+    ]
+
+    failed = False
+    for name, ok, info in checks:
+        status = "PASS" if ok else "FAIL"
+        print(f"{name}: {status} — {info}")
+        failed |= not ok
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/src/gateway/instrumentation.py
+++ b/src/gateway/instrumentation.py
@@ -6,15 +6,18 @@ import time
 from contextlib import contextmanager
 from typing import Dict, Iterator
 
+from fastapi import FastAPI
 from opentelemetry import trace
 from opentelemetry.trace import Span
 
 from src.observability.metrics import JobMetrics, get_job_metrics
+from src.observability.prom_installer import install_prometheus_endpoint
 
 __all__ = [
     "job_id_short",
     "get_job_metrics",
     "get_gateway_metrics",
+    "expose_gateway_metrics",
     "start_enqueue_span",
     "start_job_status_span",
     "start_ws_span",
@@ -37,6 +40,12 @@ def get_gateway_metrics(namespace: str | None = None) -> JobMetrics:
     """Expose job metrics with the configured namespace."""
 
     return get_job_metrics(namespace)
+
+
+def expose_gateway_metrics(app: FastAPI, *, path: str = "/metrics") -> None:
+    """Ensure the FastAPI gateway exposes a Prometheus metrics endpoint."""
+
+    install_prometheus_endpoint(app, path=path)
 
 
 @contextmanager
@@ -88,9 +97,8 @@ def prepare_enqueue_headers(
     queue: str,
     task: str,
 ) -> Dict[str, str]:
-    """Increment gauges ahead of enqueue and return Celery headers."""
+    """Return Celery headers used for downstream queue wait calculations."""
 
-    metrics.jobs_in_progress.labels(queue=queue, task=task).inc()
     enqueued_ms = int(time.time() * 1000)
     return {"x-enqueued-at-ms": str(enqueued_ms)}
 

--- a/src/observability/metrics.py
+++ b/src/observability/metrics.py
@@ -25,7 +25,15 @@ class JobMetrics:
 _METRICS_BY_NAMESPACE: Dict[Tuple[Optional[str]], JobMetrics] = {}
 
 
-def _get_or_register(metric_cls, name: str, documentation: str, *, labelnames=(), namespace: str | None = None, **kwargs):
+def _get_or_register(
+    metric_cls,
+    name: str,
+    documentation: str,
+    *,
+    labelnames=(),
+    namespace: str | None = None,
+    **kwargs,
+):
     """Return an existing collector or create a new one safely."""
 
     full_name = f"{namespace}_{name}" if namespace else name

--- a/src/observability/prom_installer.py
+++ b/src/observability/prom_installer.py
@@ -1,0 +1,102 @@
+"""Reusable Prometheus `/metrics` endpoint installer for ASGI-style apps."""
+
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+from fastapi import FastAPI  # type: ignore[attr-defined]
+from prometheus_client import CollectorRegistry, REGISTRY, generate_latest
+
+try:  # pragma: no cover - optional dependency bridge
+    from fastapi.responses import Response  # type: ignore[attr-defined]
+except Exception:  # pragma: no cover - minimal fallback
+    class Response:  # type: ignore[override]
+        def __init__(self, content: bytes, media_type: str, headers: dict[str, str] | None = None) -> None:
+            self.body = content
+            self.media_type = media_type
+            self.headers = headers or {}
+            self.status_code = 200
+
+        def __call__(self) -> "Response":  # pragma: no cover - compatibility shim
+            return self
+
+PROMETHEUS_CONTENT_TYPE = "text/plain; version=0.0.4; charset=utf-8"
+_FALLBACK_BODY = b"# HELP exporter_placeholder_info Exporter bootstrap placeholder\n" \
+    b"# TYPE exporter_placeholder_info gauge\n" \
+    b"# no_metrics_yet 1\n"
+
+__all__ = ["install_prometheus_endpoint", "PROMETHEUS_CONTENT_TYPE"]
+
+
+def _has_metrics(registry: CollectorRegistry) -> bool:
+    """Return ``True`` if the registry contains at least one sample."""
+
+    try:
+        collectors: Iterable = registry.collect()  # type: ignore[assignment]
+    except Exception:  # pragma: no cover - registry implementations may vary
+        return False
+
+    for metric in collectors:
+        samples = getattr(metric, "samples", [])
+        if samples:
+            return True
+    return False
+
+
+def _route_exists(app: FastAPI, path: str) -> bool:
+    router = getattr(app, "router", None)
+    if router is not None:
+        for route in getattr(router, "routes", []) or []:
+            route_path = getattr(route, "path", getattr(route, "path_format", None))
+            methods = getattr(route, "methods", None)
+            if route_path == path and (methods is None or "GET" in methods):
+                return True
+    for route in getattr(app, "routes", []) or []:
+        if isinstance(route, tuple):
+            route_path = route[0]
+            if route_path == path:
+                return True
+            continue
+        route_path = getattr(route, "path", None)
+        methods = getattr(route, "methods", None)
+        if route_path == path and (methods is None or "GET" in methods):
+            return True
+    return False
+
+
+def install_prometheus_endpoint(
+    app: FastAPI,
+    path: str = "/metrics",
+    registry: CollectorRegistry | None = None,
+) -> None:
+    """Expose a Prometheus metrics endpoint if it has not already been registered."""
+
+    if _route_exists(app, path):
+        return
+
+    registry = registry or REGISTRY
+
+    async def _metrics_endpoint() -> Response:
+        has_metrics = _has_metrics(registry)
+        try:
+            payload = generate_latest(registry)
+        except Exception:  # pragma: no cover - defensive fallback
+            payload = _FALLBACK_BODY
+        else:
+            if not has_metrics or not payload.strip():
+                payload = _FALLBACK_BODY
+        return Response(
+            content=payload,
+            media_type=PROMETHEUS_CONTENT_TYPE,
+            headers={"Cache-Control": "no-store"},
+        )
+
+    router = getattr(app, "router", None)
+    add_api_route = getattr(router, "add_api_route", None)
+    if callable(add_api_route):
+        add_api_route(path, _metrics_endpoint, methods=["GET"], include_in_schema=False)
+    else:
+        getter = getattr(app, "get", None)
+        if getter is None:
+            raise AttributeError("Application must expose a route registration helper")
+        getter(path)(_metrics_endpoint)

--- a/src/worker/instrumentation.py
+++ b/src/worker/instrumentation.py
@@ -4,28 +4,227 @@ from __future__ import annotations
 
 import time
 from contextlib import contextmanager
-from typing import Iterable, Iterator, Mapping, Tuple, Type
+from typing import Any, Callable, Iterable, Iterator, Mapping, Optional, Tuple, Type
+from weakref import WeakKeyDictionary
 
+from celery import Celery
+try:  # pragma: no cover - optional Celery dependency
+    from celery import signals  # type: ignore[attr-defined]
+except ImportError:  # pragma: no cover - fallback for test doubles
+    class _Signal:
+        def __init__(self) -> None:
+            self._receivers: list[tuple[Callable[..., None], Celery | None]] = []
+
+        def connect(self, receiver: Callable[..., None] | None = None, *, sender: Celery | None = None, **_: Any):
+            if receiver is None:
+                def decorator(func: Callable[..., None]) -> Callable[..., None]:
+                    self._receivers.append((func, sender))
+                    return func
+
+                return decorator
+
+            self._receivers.append((receiver, sender))
+            return receiver
+
+        def send(self, sender: Celery | None = None, *args: Any, **kwargs: Any) -> None:
+            for receiver, expected_sender in list(self._receivers):
+                if expected_sender is not None and expected_sender is not sender:
+                    continue
+                receiver(sender, *args, **kwargs)
+
+    class _SignalNamespace:
+        def __init__(self) -> None:
+            self.task_prerun = _Signal()
+            self.task_postrun = _Signal()
+            self.task_failure = _Signal()
+            self.task_retry = _Signal()
+
+    signals = _SignalNamespace()
+from fastapi import FastAPI
 from opentelemetry import trace
 from opentelemetry.trace import Span, Status, StatusCode
 
 from src.gateway.instrumentation import job_id_short
 from src.observability.metrics import JobMetrics, get_job_metrics
+from src.worker.metrics_app import create_app as _create_metrics_app
 
 __all__ = [
     "get_worker_metrics",
+    "setup_worker_signals",
+    "create_worker_metrics_app",
     "worker_task_span",
     "compute_queue_wait_ms",
 ]
 
 
 tracer = trace.get_tracer("worker.jobs")
+_REQUEST_CTX_ATTR = "_observability_ctx"
+_REQUEST_SPAN_ATTR = "_observability_span"
+_INSTRUMENTED_WORKERS: "WeakKeyDictionary[Celery, bool]" = WeakKeyDictionary()
+_METRICS_LABELS_ATTR = "_observability_metrics_labels"
+_METRICS_START_ATTR = "_observability_metrics_start"
+_METRICS_GAUGE_ATTR = "_observability_metrics_gauge_active"
 
 
 def get_worker_metrics(namespace: str | None = None) -> JobMetrics:
     """Return metrics bundle for worker processes."""
 
     return get_job_metrics(namespace)
+
+
+def create_worker_metrics_app(*, path: str = "/metrics") -> FastAPI:
+    """Return a lightweight FastAPI app that exposes worker metrics."""
+
+    return _create_metrics_app(path=path)
+
+
+def setup_worker_signals(
+    app: Celery,
+    *,
+    namespace: str | None = None,
+    retry_exception_types: Iterable[Type[BaseException]] = (),
+) -> None:
+    """Connect Celery signals to update tracing spans and Prometheus metrics."""
+
+    if _INSTRUMENTED_WORKERS.get(app):
+        return
+
+    metrics = get_worker_metrics(namespace)
+    exception_types: Tuple[Type[BaseException], ...] = tuple(retry_exception_types)
+
+    def _resolve_queue(task) -> str:
+        request = getattr(task, "request", None)
+        if request is not None:
+            delivery_info = getattr(request, "delivery_info", {}) or {}
+            routing_key = delivery_info.get("routing_key")
+            if routing_key:
+                return str(routing_key)
+            queue_name = delivery_info.get("queue")
+            if queue_name:
+                return str(queue_name)
+        return getattr(task, "queue", "calculator")
+
+    def _task_request(task):
+        return getattr(task, "request", None)
+
+    def _store_labels(request, queue: str, task_name: str) -> None:
+        setattr(request, _METRICS_LABELS_ATTR, (queue, task_name))
+        setattr(request, _METRICS_GAUGE_ATTR, True)
+
+    def _labels_from_request(request) -> Tuple[str, str] | None:
+        labels = getattr(request, _METRICS_LABELS_ATTR, None)
+        if isinstance(labels, tuple) and len(labels) == 2:
+            return str(labels[0]), str(labels[1])
+        return None
+
+    def _decrement_in_progress(request) -> Tuple[str, str] | None:
+        labels = _labels_from_request(request)
+        if labels and getattr(request, _METRICS_GAUGE_ATTR, False):
+            queue, task_name = labels
+            metrics.jobs_in_progress.labels(queue=queue, task=task_name).dec()
+            setattr(request, _METRICS_GAUGE_ATTR, False)
+        return labels
+
+    @signals.task_prerun.connect(sender=app)  # pragma: no cover - Celery wiring
+    def _task_prerun(sender, task_id, task, *_, **__):
+        request = _task_request(task)
+        if request is None:
+            return
+        queue = _resolve_queue(task)
+        task_name = task.name
+        metrics.jobs_in_progress.labels(queue=queue, task=task_name).inc()
+        _store_labels(request, queue, task_name)
+        setattr(request, _METRICS_START_ATTR, time.perf_counter())
+
+        headers = getattr(request, "headers", None)
+        queue_wait_ms = compute_queue_wait_ms(headers)
+        if queue_wait_ms is not None:
+            metrics.job_wait_time_seconds.labels(queue=queue).observe(queue_wait_ms / 1000.0)
+
+        context = worker_task_span(
+            job_id=task_id,
+            queue=queue,
+            task=task_name,
+            headers=headers,
+            metrics=metrics,
+            retry_exception_types=exception_types,
+            manage_metrics=False,
+        )
+        span = context.__enter__()
+        setattr(request, _REQUEST_CTX_ATTR, context)
+        setattr(request, _REQUEST_SPAN_ATTR, span)
+
+    @signals.task_failure.connect(sender=app)  # pragma: no cover - Celery wiring
+    def _task_failure(sender, task_id, exception, traceback, einfo, task, **kwargs):
+        request = _task_request(task)
+        if request is None:
+            return
+        span = getattr(request, _REQUEST_SPAN_ATTR, None)
+        if span is not None:
+            try:
+                span.record_exception(exception)
+            except Exception:  # pragma: no cover - defensive
+                pass
+            span.set_status(Status(StatusCode.ERROR))
+            span.set_attribute("outcome", "failed")
+
+        labels = _decrement_in_progress(request)
+        if labels is None:
+            labels = (_resolve_queue(task), task.name)
+        metrics.jobs_failed.labels(queue=labels[0], task=labels[1]).inc()
+
+    @signals.task_retry.connect(sender=app)  # pragma: no cover - Celery wiring
+    def _task_retry(sender, request, reason, einfo, **kwargs):
+        span = getattr(request, _REQUEST_SPAN_ATTR, None)
+        if span is None:
+            return
+        if reason is not None:
+            try:
+                span.record_exception(reason)
+            except Exception:  # pragma: no cover - defensive
+                pass
+        span.set_attribute("outcome", "retry")
+        span.set_status(Status(StatusCode.ERROR))
+        _decrement_in_progress(request)
+
+    @signals.task_postrun.connect(sender=app)  # pragma: no cover - Celery wiring
+    def _task_postrun(sender, task_id, task, retval, state, **kwargs):
+        request = _task_request(task)
+        if request is None:
+            return
+        context = getattr(request, _REQUEST_CTX_ATTR, None)
+        span = getattr(request, _REQUEST_SPAN_ATTR, None)
+
+        if span is not None and state:
+            outcome = str(state).upper()
+            if outcome == "RETRY":
+                span.set_attribute("outcome", "retry")
+            elif outcome == "FAILURE":
+                span.set_attribute("outcome", "failed")
+
+        labels = _decrement_in_progress(request)
+        if labels is None:
+            labels = (_resolve_queue(task), task.name)
+
+        start_time = getattr(request, _METRICS_START_ATTR, None)
+        if isinstance(start_time, float):
+            runtime = max(0.0, time.perf_counter() - start_time)
+            metrics.celery_task_runtime_seconds.labels(task=labels[1]).observe(runtime)
+
+        if context is not None:
+            context.__exit__(None, None, None)
+
+        for attr in (
+            _REQUEST_CTX_ATTR,
+            _REQUEST_SPAN_ATTR,
+            _METRICS_LABELS_ATTR,
+            _METRICS_START_ATTR,
+            _METRICS_GAUGE_ATTR,
+        ):
+            if hasattr(request, attr):
+                delattr(request, attr)
+
+    _INSTRUMENTED_WORKERS[app] = True
 
 
 def compute_queue_wait_ms(headers: Mapping[str, str] | None) -> float | None:
@@ -51,9 +250,10 @@ def worker_task_span(
     queue: str,
     task: str,
     headers: Mapping[str, str] | None,
-    metrics: JobMetrics,
+    metrics: Optional[JobMetrics],
     *,
     retry_exception_types: Iterable[Type[BaseException]] = (),
+    manage_metrics: bool = True,
 ) -> Iterator[Span]:
     """Context manager capturing worker execution spans and metrics."""
 
@@ -65,16 +265,21 @@ def worker_task_span(
     }
     if queue_wait_ms is not None:
         attributes["queue_wait_ms"] = queue_wait_ms
+
+    exception_types: Tuple[Type[BaseException], ...] = tuple(retry_exception_types)
     start_time = time.perf_counter()
     outcome = "success"
-    exception_types: Tuple[Type[BaseException], ...] = tuple(retry_exception_types)
+
+    metrics_enabled = manage_metrics and metrics is not None
+    if metrics_enabled:
+        metrics.jobs_in_progress.labels(queue=queue, task=task).inc()
 
     with tracer.start_as_current_span("jobs.execute", attributes=attributes) as span:
         for key, value in attributes.items():
             span.set_attribute(key, value)
         span.add_event("job.id", {"job_id": job_id})
         span.set_attribute("component", "worker")
-        if queue_wait_ms is not None:
+        if metrics_enabled and queue_wait_ms is not None:
             metrics.job_wait_time_seconds.labels(queue=queue).observe(queue_wait_ms / 1000.0)
         try:
             yield span
@@ -99,8 +304,9 @@ def worker_task_span(
         finally:
             worker_process_ms = (time.perf_counter() - start_time) * 1000.0
             span.set_attribute("worker_process_ms", worker_process_ms)
-            metrics.celery_task_runtime_seconds.labels(task=task).observe(worker_process_ms / 1000.0)
-            metrics.jobs_in_progress.labels(queue=queue, task=task).dec()
-            final_outcome = getattr(span, "attributes", {}).get("outcome", outcome)
-            if final_outcome == "failed":
-                metrics.jobs_failed.labels(queue=queue, task=task).inc()
+            if metrics_enabled:
+                metrics.celery_task_runtime_seconds.labels(task=task).observe(worker_process_ms / 1000.0)
+                metrics.jobs_in_progress.labels(queue=queue, task=task).dec()
+                final_outcome = getattr(span, "attributes", {}).get("outcome", outcome)
+                if final_outcome == "failed":
+                    metrics.jobs_failed.labels(queue=queue, task=task).inc()

--- a/src/worker/metrics_app.py
+++ b/src/worker/metrics_app.py
@@ -1,0 +1,31 @@
+"""FastAPI application exposing worker metrics for sidecar deployments.
+
+Usage examples
+--------------
+* Development::
+
+    uvicorn worker.metrics_app:app --port 9109
+
+* Container sidecar::
+
+    uvicorn worker.metrics_app:app --host 0.0.0.0 --port 9109
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from src.observability.prom_installer import install_prometheus_endpoint
+
+__all__ = ["app", "create_app"]
+
+
+def create_app(*, path: str = "/metrics") -> FastAPI:
+    """Create a FastAPI application that serves Prometheus metrics."""
+
+    app = FastAPI(title="Worker Metrics")
+    install_prometheus_endpoint(app, path=path)
+    return app
+
+
+app = create_app()

--- a/tests/metrics/test_metrics_endpoint.py
+++ b/tests/metrics/test_metrics_endpoint.py
@@ -1,0 +1,77 @@
+import asyncio
+import inspect
+
+from fastapi import FastAPI
+from prometheus_client import CollectorRegistry
+
+from src.observability.prom_installer import (
+    PROMETHEUS_CONTENT_TYPE,
+    install_prometheus_endpoint,
+)
+
+
+def _get_metrics_response(app: FastAPI, path: str = "/metrics"):
+    routes = list(getattr(app, "routes", []) or [])
+    if not routes:
+        router = getattr(app, "router", None)
+        routes = list(getattr(router, "routes", []) or []) if router is not None else []
+
+    for route in routes:
+        handler = None
+        if isinstance(route, tuple):
+            route_path, handler = route[0], route[1]
+        else:
+            route_path = getattr(route, "path", getattr(route, "path_format", None))
+            handler = getattr(route, "endpoint", None) or getattr(route, "app", None)
+        if route_path == path and handler is not None:
+            result = handler()
+            if inspect.isawaitable(result):
+                return asyncio.run(result)
+            return result
+    raise AssertionError(f"No route registered for {path}")
+
+
+def _route_count(app: FastAPI, path: str) -> int:
+    count = 0
+    for route in getattr(app, "routes", []) or []:
+        if isinstance(route, tuple) and route[0] == path:
+            count += 1
+    router = getattr(app, "router", None)
+    if router is not None:
+        for route in getattr(router, "routes", []) or []:
+            if getattr(route, "path", getattr(route, "path_format", None)) == path:
+                count += 1
+    return count
+
+
+def test_install_prometheus_endpoint_is_idempotent_and_serves_fallback() -> None:
+    app = FastAPI()
+    registry = CollectorRegistry()
+
+    install_prometheus_endpoint(app, registry=registry)
+    install_prometheus_endpoint(app, registry=registry)
+
+    response = _get_metrics_response(app)
+
+    assert getattr(response, "status_code", 200) == 200
+    media_type = getattr(response, "media_type", None)
+    assert media_type == PROMETHEUS_CONTENT_TYPE
+
+    body_lines = (getattr(response, "body", b"") or b"").decode("utf-8").splitlines()
+    assert body_lines[0].startswith("# HELP")
+    assert body_lines[1].startswith("# TYPE")
+    assert "# no_metrics_yet 1" in "\n".join(body_lines)
+
+    assert _route_count(app, "/metrics") == 1
+
+
+def test_install_prometheus_endpoint_with_existing_metrics() -> None:
+    app = FastAPI()
+    install_prometheus_endpoint(app)
+
+    response = _get_metrics_response(app)
+
+    assert getattr(response, "media_type", None) == PROMETHEUS_CONTENT_TYPE
+    body_text = (getattr(response, "body", b"") or b"").decode("utf-8")
+    assert "# HELP" in body_text
+    assert "# TYPE" in body_text

--- a/tests/metrics/test_metrics_endpoints.py
+++ b/tests/metrics/test_metrics_endpoints.py
@@ -1,0 +1,53 @@
+import asyncio
+import inspect
+
+from fastapi import FastAPI
+
+from src.gateway.instrumentation import expose_gateway_metrics, get_gateway_metrics
+from src.worker.instrumentation import create_worker_metrics_app, get_worker_metrics
+
+
+def _get_response_text(app: FastAPI, path: str = "/metrics") -> str:
+    for route_path, handler in getattr(app, "routes", []):
+        if route_path == path:
+            result = handler()
+            if inspect.isawaitable(result):
+                response = asyncio.run(result)
+            else:
+                response = result
+            assert response.status_code == 200
+            body = getattr(response, "body", b"")
+            if isinstance(body, bytes):
+                return body.decode("utf-8")
+            return str(body)
+    raise AssertionError(f"No route registered for {path}")
+
+
+def test_gateway_metrics_endpoint_exposes_registry() -> None:
+    app = FastAPI()
+    expose_gateway_metrics(app)
+
+    metrics = get_gateway_metrics(namespace="gateway_test")
+    metrics.jobs_enqueued_total.labels(queue="calculator").inc()
+
+    body = _get_response_text(app)
+    assert "gateway_test_jobs_enqueued_total" in body
+
+
+def test_worker_metrics_app_exposes_metrics() -> None:
+    app = create_worker_metrics_app(path="/metrics")
+
+    metrics = get_worker_metrics(namespace="worker_test")
+    metrics.jobs_failed.labels(queue="calculator", task="worker.task").inc()
+
+    body = _get_response_text(app)
+    assert "worker_test_jobs_failed" in body
+
+
+def test_metrics_endpoint_registration_is_idempotent() -> None:
+    app = FastAPI()
+    expose_gateway_metrics(app)
+    expose_gateway_metrics(app)
+
+    body = _get_response_text(app)
+    assert "# TYPE" in body

--- a/tests/metrics/test_worker_signals.py
+++ b/tests/metrics/test_worker_signals.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import time
+
+from celery import Celery
+
+from src.worker.instrumentation import get_worker_metrics, setup_worker_signals, signals
+
+
+class _TaskRequest:
+    def __init__(self, task_id: str, queue: str) -> None:
+        self.id = task_id
+        self.headers = {"x-enqueued-at-ms": str(int(time.time() * 1000) - 250)}
+        self.delivery_info = {"routing_key": queue}
+        self.retries = 0
+
+
+class _Task:
+    def __init__(self, task_id: str, queue: str, name: str = "worker.task") -> None:
+        self.name = name
+        self.queue = queue
+        self.request = _TaskRequest(task_id, queue)
+
+
+def _metric_value(metric, **labels) -> float:
+    for collector in metric.collect():
+        for sample in collector.samples:
+            if all(sample.labels.get(k) == v for k, v in labels.items()):
+                return sample.value
+    return 0.0
+
+
+def test_worker_signal_lifecycle_updates_gauge_and_histogram() -> None:
+    namespace = "worker_signal_success"
+    metrics = get_worker_metrics(namespace=namespace)
+    app = Celery("worker-signal-success")
+    setup_worker_signals(app, namespace=namespace)
+
+    task = _Task("job-1", "calculator")
+
+    signals.task_prerun.send(sender=app, task_id=task.request.id, task=task)
+    assert _metric_value(metrics.jobs_in_progress, queue="calculator", task="worker.task") == 1.0
+
+    signals.task_postrun.send(
+        sender=app,
+        task_id=task.request.id,
+        task=task,
+        retval=None,
+        state="SUCCESS",
+    )
+
+    assert _metric_value(metrics.jobs_in_progress, queue="calculator", task="worker.task") == 0.0
+    assert _metric_value(metrics.celery_task_runtime_seconds, task="worker.task") > 0.0
+
+
+def test_worker_signal_failure_increments_failure_counter() -> None:
+    namespace = "worker_signal_failure_metrics"
+    metrics = get_worker_metrics(namespace=namespace)
+    app = Celery("worker-signal-failure")
+    setup_worker_signals(app, namespace=namespace)
+
+    task = _Task("job-2", "calculator")
+
+    signals.task_prerun.send(sender=app, task_id=task.request.id, task=task)
+    signals.task_failure.send(
+        sender=app,
+        task_id=task.request.id,
+        exception=RuntimeError("boom"),
+        traceback=None,
+        einfo=None,
+        task=task,
+    )
+
+    assert _metric_value(metrics.jobs_in_progress, queue="calculator", task="worker.task") == 0.0
+    assert _metric_value(metrics.jobs_failed, queue="calculator", task="worker.task") == 1.0
+
+    signals.task_postrun.send(
+        sender=app,
+        task_id=task.request.id,
+        task=task,
+        retval=None,
+        state="FAILURE",
+    )
+
+    assert _metric_value(metrics.celery_task_runtime_seconds, task="worker.task") > 0.0
+
+
+def test_worker_signal_retry_resets_in_progress_gauge() -> None:
+    namespace = "worker_signal_retry"
+    metrics = get_worker_metrics(namespace=namespace)
+    app = Celery("worker-signal-retry")
+    setup_worker_signals(app, namespace=namespace)
+
+    task = _Task("job-3", "calculator")
+
+    signals.task_prerun.send(sender=app, task_id=task.request.id, task=task)
+    assert _metric_value(metrics.jobs_in_progress, queue="calculator", task="worker.task") == 1.0
+
+    signals.task_retry.send(
+        sender=app,
+        request=task.request,
+        reason=RuntimeError("temporary"),
+        einfo=None,
+    )
+
+    assert _metric_value(metrics.jobs_in_progress, queue="calculator", task="worker.task") == 0.0
+
+    signals.task_prerun.send(sender=app, task_id=task.request.id, task=task)
+    assert _metric_value(metrics.jobs_in_progress, queue="calculator", task="worker.task") == 1.0

--- a/tests/observability/test_worker_signals_observability.py
+++ b/tests/observability/test_worker_signals_observability.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import time
+
+from celery import Celery
+
+from src.worker.instrumentation import get_worker_metrics, setup_worker_signals, signals
+
+
+class _TaskRequest:
+    def __init__(self, task_id: str, queue: str) -> None:
+        self.id = task_id
+        self.headers = {"x-enqueued-at-ms": str(int(time.time() * 1000) - 250)}
+        self.delivery_info = {"routing_key": queue}
+
+
+class _Task:
+    def __init__(self, task_id: str, queue: str, name: str = "worker.task") -> None:
+        self.name = name
+        self.queue = queue
+        self.request = _TaskRequest(task_id, queue)
+
+
+def _get_metric_value(metric, sample_name: str, **labels) -> float:
+    for collector in metric.collect():
+        for sample in collector.samples:
+            if sample.name.endswith(sample_name) and all(sample.labels.get(k) == v for k, v in labels.items()):
+                return sample.value
+    return 0.0
+
+
+def test_worker_signal_lifecycle_updates_metrics() -> None:
+    namespace = "worker_signal"
+    metrics = get_worker_metrics(namespace=namespace)
+    app = Celery("test-worker")
+    setup_worker_signals(app, namespace=namespace)
+
+    task = _Task("job-1", "calculator", "worker.task")
+
+    signals.task_prerun.send(sender=app, task_id=task.request.id, task=task)
+    assert _get_metric_value(
+        metrics.jobs_in_progress,
+        "_jobs_in_progress",
+        queue="calculator",
+        task="worker.task",
+    ) == 1.0
+
+    signals.task_postrun.send(
+        sender=app,
+        task_id=task.request.id,
+        task=task,
+        retval=None,
+        state="SUCCESS",
+    )
+    assert _get_metric_value(
+        metrics.jobs_in_progress,
+        "_jobs_in_progress",
+        queue="calculator",
+        task="worker.task",
+    ) == 0.0
+
+
+def test_worker_signal_failure_records_counter() -> None:
+    namespace = "worker_signal_failure"
+    metrics = get_worker_metrics(namespace=namespace)
+    app = Celery("test-worker-failure")
+    setup_worker_signals(app, namespace=namespace)
+
+    task = _Task("job-2", "calculator", "worker.task")
+
+    signals.task_prerun.send(sender=app, task_id=task.request.id, task=task)
+    signals.task_failure.send(
+        sender=app,
+        task_id=task.request.id,
+        exception=RuntimeError("boom"),
+        traceback=None,
+        einfo=None,
+        task=task,
+    )
+    signals.task_postrun.send(
+        sender=app,
+        task_id=task.request.id,
+        task=task,
+        retval=None,
+        state="FAILURE",
+    )
+
+    assert _get_metric_value(
+        metrics.jobs_failed,
+        "_jobs_failed",
+        queue="calculator",
+        task="worker.task",
+    ) == 1.0


### PR DESCRIPTION
## Summary
- add a reusable `install_prometheus_endpoint` helper that works with the in-repo FastAPI shim and shared `CollectorRegistry`
- update gateway and worker wiring to rely on the shared installer, including a standalone worker metrics app and richer signal-driven metrics that now mark retries as errors and release gauges safely
- extend the Prometheus shim and observability release notes, and add regression tests for the metrics endpoint and worker signal lifecycle
- harden worker retry instrumentation with additional unit coverage to guarantee gauges reset when Celery emits `task_retry`

## Testing
- pytest tests/metrics tests/observability -q

------
https://chatgpt.com/codex/tasks/task_e_68e22056f1ec832dadccd9807b678d71