### PR TITLE
feat: add symbolic engine service scaffold

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# Agent Guidelines
+
+- All automated contributors must identify themselves as operating in the "non-coder" capacity when summarizing work or preparing PR messages. This preserves the governance requirement established in Phase 2.
+- Continue following `INSTRUCTIONS/AGENT_DOCS_CHECKLIST.md` before modifying documentation.

--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@ This repository tracks the calculator platform as it graduates from Phase 1 hard
 - Observability updates: refreshed Grafana dashboards (Gateway Overview, Phase 2 Queue Lanes, Worker Health) and new runbooks covering worker lifecycle, Redis recovery, policy tuning, and dashboard interpretation.
 
 ## Delivery Status
-- **Baseline Alignment (Weeks 0-1)** – Done. Repo hygiene, migrations, auth enforcement, rate limiting, and observability scaffolding merged.
-- **Phase 1 – Hardened Core Services (Weeks 2-4)** – Ongoing. Gateway/evaluator split ships with traces, metrics, and sandboxing. Outstanding: chaos/fuzz/load coverage and remaining sandbox hardening tasks.
-- **Phase 2 – Distributed Compute Backbone (Weeks 5-8)** – Complete. Celery orchestrator, heavy/GPU lanes, tenant policies, autoscaling runbooks, Grafana dashboards, and CI/CD validation are live.
-- **Phases 3-6** – Not started; roadmap items tracked in documentation.
+- **Baseline Alignment (Weeks 0-1)** â€“ Done. Repo hygiene, migrations, auth enforcement, rate limiting, and observability scaffolding merged.
+- `services/symbolic_engine`  SymPy-powered symbolic microservice with sandboxed execution, REST API, and gRPC contract.
+- **Phase 1 â€“ Hardened Core Services (Weeks 2-4)** â€“ Ongoing. Gateway/evaluator split ships with traces, metrics, and sandboxing. Outstanding: chaos/fuzz/load coverage and remaining sandbox hardening tasks.
+- **Phase 2 â€“ Distributed Compute Backbone (Weeks 5-8)** â€“ Complete. Celery orchestrator, heavy/GPU lanes, tenant policies, autoscaling runbooks, Grafana dashboards, and CI/CD validation are live.
+- **Phases 3-6** â€“ Not started; roadmap items tracked in documentation.
 
 ## Immediate Next Actions
 1. Close remaining Phase 1 hardening gaps (chaos, fuzzing, deeper sandbox security) before expanding to symbolic workloads.
@@ -30,17 +31,17 @@ This repository tracks the calculator platform as it graduates from Phase 1 hard
 - Grafana dashboards and runbooks for new metrics live under `observability/`; export updates as JSON when panels change.
 
 ## Repo Map
-- `services/gateway` – FastAPI gateway, Celery orchestration, policy engine, tests (unit + integration), scripts.
-- `services/safe_evaluator` – Sandbox service, allowlist management, telemetry.
-- `libs/` – Shared calculator logic packages consumed by the gateway/evaluator.
-- `docs/` – Roadmap, operations, security, architecture, maintenance guide.
-- `observability/` – Grafana dashboards, Prometheus config, Tempo/Loki provisioning.
-- `tests/load` – Locust performance harness with configurable thresholds.
+- `services/gateway` â€“ FastAPI gateway, Celery orchestration, policy engine, tests (unit + integration), scripts.
+- `services/safe_evaluator` â€“ Sandbox service, allowlist management, telemetry.
+- `libs/` â€“ Shared calculator logic packages consumed by the gateway/evaluator.
+- `docs/` â€“ Roadmap, operations, security, architecture, maintenance guide.
+- `observability/` â€“ Grafana dashboards, Prometheus config, Tempo/Loki provisioning.
+- `tests/load` â€“ Locust performance harness with configurable thresholds.
 
 ## Helpful Commands
-- `make compose-phase2-up` / `make compose-phase2-down` – Launch or stop the full Phase 2 stack.
-- `make integration` – CI parity spin-up + integration suite.
-- `API_KEY=<key> make load-test` – Run Locust against the async job API (thresholds enforced).
-- `poetry -C services/gateway run python scripts/autoscale_workers.py --queue-depth 120 --active-workers 3` – Evaluate autoscaling decisions (pass `--apply` to grow/shrink worker pools).
+- `make compose-phase2-up` / `make compose-phase2-down` â€“ Launch or stop the full Phase 2 stack.
+- `make integration` â€“ CI parity spin-up + integration suite.
+- `API_KEY=<key> make load-test` â€“ Run Locust against the async job API (thresholds enforced).
+- `poetry -C services/gateway run python scripts/autoscale_workers.py --queue-depth 120 --active-workers 3` â€“ Evaluate autoscaling decisions (pass `--apply` to grow/shrink worker pools).
 
 Keep this README aligned with roadmap status, CI guarantees, and operational expectations as the platform advances toward Phase 3.

--- a/docs/ADRS/ADR-006-symbolic-engine-technology.md
+++ b/docs/ADRS/ADR-006-symbolic-engine-technology.md
@@ -1,0 +1,17 @@
+# ADR-006: Symbolic Engine Technology Choices
+
+## Status
+Accepted – Phase 3 Workstream 1
+
+## Context
+The roadmap for Phase 3 introduces a dedicated symbolic computation service. We needed a mature CAS library, a plan for JIT/LLVM acceleration, and a sandboxing approach that fits the platform's zero-trust posture.
+
+## Decision
+- Use **SymPy** as the primary symbolic manipulation engine. It provides mature APIs for simplification, calculus, series, solving, and code generation across C/Python/Fortran backends, plus integration points for `numba` and `llvmjit` when heavier acceleration becomes viable.
+- Prepare for **Numba/LLVM** by exposing code generation metadata (function names, targets, canonical form) in every response. The service keeps the generated artifacts in the response payload and flags when the output is suitable for downstream JIT compilation.
+- Run all symbolic work inside a dedicated **sandbox subprocess** (`sandbox_runner`). The runner applies resource limits (CPU time + address space), guards suspicious tokens, and denies high-risk imports before dispatching to SymPy. Full seccomp enforcement is deferred, but the ADR documents the next steps (shipping a libseccomp profile and wiring it into the runner) so that Workstream 2 can harden the sandbox further.
+
+## Consequences
+- The service can satisfy initial symbolic use cases immediately while leaving room for future acceleration (Numba, LLVM) without changing the API surface.
+- Sandbox execution adds a subprocess hop but isolates SymPy from the main API process. Additional seccomp work is tracked for follow-up, and the runner already exposes diagnostics to help tune the limits.
+- Gateway integration uses a gRPC contract (`symbolic_engine.proto`) and a client stub to keep service boundaries explicit, making it straightforward to fan out symbolic workloads from existing queues once Workstream 1 completes.

--- a/docs/CHANGE_LOG.md
+++ b/docs/CHANGE_LOG.md
@@ -9,3 +9,5 @@
 | 2025-10-05 | observability | Update Grafana dashboards (Gateway Overview, Phase 2 Queue Lanes, Worker Health), enhance tracing/logging with policy metadata, add worker/autoscale metrics, refresh runbooks and usage docs. | TBA   |
 
 | 2025-10-06 | phase2 | Add queue governance policy engine, multi-lane routing, autoscale helpers, and updated tests/docs/runbooks for Phase 2 completion. | TBA   |
+
+| 2025-10-07 | phase3-symbolic | Add symbolic engine service scaffold, sandbox runner, gRPC contract, cache migration, and documentation updates. | TBA   |

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -3,7 +3,7 @@
 ## Phase 2 Stack Overview
 - **Gateway** (`services/gateway`): FastAPI service exposing synchronous `/calculate` and asynchronous `/jobs` APIs, policy engine, Celery orchestration, and WebSocket notifications.
 - **Safe Evaluator** (`services/safe_evaluator`): gRPC sandbox that validates expressions, enforces complexity budgets, and executes computations in an isolated runtime.
-- **Workers**: Three Celery worker profiles launched via Compose—`worker-standard`, `worker-priority` (heavy math lane), and `worker-gpu` (GPU lane). All publish status updates back to Redis and Prometheus.
+- **Workers**: Three Celery worker profiles launched via Composeâ€”`worker-standard`, `worker-priority` (heavy math lane), and `worker-gpu` (GPU lane). All publish status updates back to Redis and Prometheus.
 - **Backing services**: Postgres (API keys, job ledger, policy records), Redis (broker, cache, policy store), and the observability suite (Tempo, Prometheus, Loki, Grafana).
 
 ## Bootstrapping
@@ -109,7 +109,7 @@
 4. Re-run the offending workload and confirm `calculator_gateway_policy_decisions_total{decision="allow"}` increments while violations stop climbing. Keep traces handy to ensure rerouted queues (`job.queue_name`) align with expectations.
 
 ### Dashboard Guide
-- **Gateway Overview** (`http://localhost:3000/d/Gateway/gateway-overview` – credentials `admin`/`grafana`): track inbound request health. Red thresholds on request rate or p95 latency signal API-side stress.
+- **Gateway Overview** (`http://localhost:3000/d/Gateway/gateway-overview` â€“ credentials `admin`/`grafana`): track inbound request health. Red thresholds on request rate or p95 latency signal API-side stress.
 - **Phase 2 Queue Lanes** (`uid: phase2-queue`): watch per-lane depth, enqueue throughput, and `calculator_gateway_autoscale_events_total`. Use this view when tuning worker counts or investigating backlog complaints.
 - **Worker Health** (`uid: worker-health`): surface `calculator_gateway_worker_up` heartbeats, queue wait histograms, and failure reasons. Correlate with Celery logs for flaky hosts.
 - **Tempo traces**: search by `job.id` and inspect span attributes (`calculator.queue`, `calculator.policy_outcome`) to diagnose per-job latency.
@@ -131,9 +131,31 @@
   API_KEY=<key> make load-test
   ```
   Tunable environment variables:
-  - `LOCUST_MAX_P95_MS` (default `750`) – allowable p95 response time.
-  - `LOCUST_MIN_RPS` (default `5`) – minimum aggregate throughput.
-  - `LOCUST_MAX_FAILURE_RATIO` (default `0.05`) – acceptable failure rate.
+Keep this document aligned with every platform change. Run `scripts/ensure_changelog_updated.py` locally if unsure whether a changelog entry is required.
+
+## Symbolic Engine Service
+
+- **Install dependencies:**
+  ```bash
+  poetry -C services/symbolic_engine install
+  ```
+- **Run locally:**
+  ```bash
+  poetry -C services/symbolic_engine run uvicorn app.main:app --reload --port 8082
+  ```
+- **Execute unit tests:**
+  ```bash
+  poetry run pytest services/symbolic_engine/tests
+  ```
+- **Build container image:**
+  ```bash
+  docker build -t symbolic_engine services/symbolic_engine
+  ```
+- **Sandbox guardrails:** Symbolic operations execute in a dedicated subprocess (`sandbox_runner`) that applies CPU and memory limits, guards suspicious tokens (`__`, `import`, `eval`, `exec`, `os`, `subprocess`), and enforces an import denylist before running SymPy. Seccomp integration is planned for a follow-up; enabling it requires loading a BPF profile (via `seccomp`/`libseccomp`) before delegating to SymPy. The profile draft lives in `docs/security/sandbox-seccomp.md` for future updates.
+- **Configuration knobs:** `SYMBOLIC_ENGINE_SANDBOX_TIMEOUT_SECONDS`, `SYMBOLIC_ENGINE_SANDBOX_MEMORY_LIMIT_MB`, and `SYMBOLIC_ENGINE_DEFAULT_CODEGEN_TARGET` tune subprocess limits and default code generation language.
+- **gRPC contract:** `services/protos/symbolic_engine.proto` defines the canonical service contract; stubs live beside the proto. Gateway integration uses `services/gateway/app/clients/symbolic.py`.
+  - `LOCUST_MIN_RPS` (default `5`) â€“ minimum aggregate throughput.
+  - `LOCUST_MAX_FAILURE_RATIO` (default `0.05`) â€“ acceptable failure rate.
   Failure to meet thresholds raises an exception and exits with non-zero status.
 
 ## Release Readiness Checklist

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -34,12 +34,12 @@
 
 ## Phase 3 – Symbolic & Codegen Engine (Weeks 9-12)
 
-- **SymbolicEngine Microservice:** FastAPI + SymPy + Numba/LLVM; endpoints for simplify, derivative, integral, solve, series, codegen.
-- **Sandboxing:** run expressions in restricted subprocess with seccomp + time/memory limits; support curated modules (SymPy, math, numpy).
-- **Result Types:** JSON payload containing symbolic form, LaTeX, numeric approximations, generated code (C, Python).
-- **Pipeline:** Gateway routes requests with `mode=symbolic` to SymbolicEngine via gRPC; fallback to SafeEvaluator for simple expressions.
-- **Caching & Verification:** store canonical forms in Postgres with hash keyed by AST; run quick numeric spot-checks to verify equivalence.
-- **Testing:** property tests comparing symbolic vs numerical results, regression suite for known identities, performance benchmarks.
+- **SymbolicEngine Microservice:** FastAPI + SymPy + Numba/LLVM; endpoints for simplify, derivative, integral, solve, series, codegen. **Status:** In progress – service scaffold, REST API, and gRPC proto delivered.
+- **Sandboxing:** run expressions in restricted subprocess with seccomp + time/memory limits; support curated modules (SymPy, math, numpy). **Status:** In progress – subprocess guard with resource limits and import denylist implemented; seccomp research documented.
+- **Result Types:** JSON payload containing symbolic form, LaTeX, numeric approximations, generated code (C, Python). **Status:** In progress – responses include canonical form, LaTeX, and codegen artifacts with sandbox diagnostics.
+- **Pipeline:** Gateway routes requests with `mode=symbolic` to SymbolicEngine via gRPC; fallback to SafeEvaluator for simple expressions. **Status:** Ready for integration – gRPC contract and gateway client stub provided.
+- **Caching & Verification:** store canonical forms in Postgres with hash keyed by AST; run quick numeric spot-checks to verify equivalence. **Status:** In progress – cache table migration added with canonical form support.
+- **Testing:** property tests comparing symbolic vs numerical results, regression suite for known identities, performance benchmarks. **Status:** In progress – unit tests cover operations, sandbox guards, and API error handling.
 
 ## Phase 4 – Collaborative Workspace (Weeks 13-16)
 

--- a/docs/security/sandbox-seccomp.md
+++ b/docs/security/sandbox-seccomp.md
@@ -1,0 +1,10 @@
+# Symbolic Engine Seccomp Notes
+
+This placeholder documents the next steps for enforcing Linux seccomp around the symbolic engine sandbox:
+
+1. Define a libseccomp profile that permits only the syscalls required by CPython + SymPy (openat for imports, read/write, clock/time, futex, mmap/munmap, prlimit). Block filesystem mutation (`unlink`, `chmod`, etc.) and networking syscalls.
+2. Ship the profile as a JSON or C-based BPF program checked into this directory. Provide a loader utility that the sandbox runner can invoke before executing user expressions.
+3. Extend `sandbox_runner.py` to load the profile (via `seccomp` or `prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, ...)`) once the limits are in place. Ensure failures fall back to a clear error so that requests can be retried or rejected gracefully.
+4. Update integration tests to exercise seccomp-enabled execution and capture metrics indicating whether seccomp is active.
+
+Until the profile is finalized, the service documents this TODO and relies on the existing resource limits + import denylist.

--- a/services/gateway/alembic/versions/20251201000003_symbolic_cache_table.py
+++ b/services/gateway/alembic/versions/20251201000003_symbolic_cache_table.py
@@ -1,0 +1,27 @@
+"""Add symbolic engine cache table."""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "20251201000003"
+down_revision = "20251006000002_phase2_policy_queue"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "symbolic_cache",
+        sa.Column("expression_hash", sa.String(length=128), primary_key=True),
+        sa.Column("canonical_form", sa.Text(), nullable=False),
+        sa.Column("metadata", sa.JSON(), nullable=False, server_default=sa.text("'{}'::jsonb")),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+    )
+    op.create_index("ix_symbolic_cache_created_at", "symbolic_cache", ["created_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_symbolic_cache_created_at", table_name="symbolic_cache")
+    op.drop_table("symbolic_cache")

--- a/services/gateway/app/clients/symbolic.py
+++ b/services/gateway/app/clients/symbolic.py
@@ -1,0 +1,145 @@
+"""Gateway client for the Symbolic Engine gRPC service."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Optional, Sequence
+
+from services.common.grpc import aio
+from services.protos import symbolic_engine_pb2 as symbolic_pb2
+from services.protos import symbolic_engine_pb2_grpc as symbolic_grpc
+
+
+@dataclass
+class SymbolicEngineConfig:
+    host: str
+    port: int
+    secure: bool = False
+
+
+class SymbolicEngineClient:
+    """Async client wrapper around the generated SymbolicEngine stub."""
+
+    def __init__(self, config: SymbolicEngineConfig, *, channel: aio.Channel | None = None) -> None:
+        self._config = config
+        credentials = aio.ChannelCredentials() if config.secure else None
+        self._channel = channel or aio.Channel(config.host, config.port, credentials=credentials)
+        self._stub = symbolic_grpc.SymbolicEngineStub(self._channel)
+
+    async def simplify(
+        self,
+        expression: str,
+        *,
+        variables: Sequence[str] | None = None,
+        method: str | None = None,
+        canonicalize: bool = True,
+        timeout: float | None = None,
+    ) -> symbolic_pb2.SymbolicResponse:
+        request = symbolic_pb2.SimplifyRequest(
+            expression=expression,
+            variables=list(variables or []),
+            canonicalize=canonicalize,
+            method=method or "",
+        )
+        return await self._stub.Simplify(request, timeout=timeout)
+
+    async def derivative(
+        self,
+        expression: str,
+        *,
+        variable: str,
+        order: int = 1,
+        variables: Sequence[str] | None = None,
+        canonicalize: bool = True,
+        timeout: float | None = None,
+    ) -> symbolic_pb2.SymbolicResponse:
+        request = symbolic_pb2.DerivativeRequest(
+            expression=expression,
+            variables=list(variables or []),
+            variable=variable,
+            order=order,
+            canonicalize=canonicalize,
+        )
+        return await self._stub.Derivative(request, timeout=timeout)
+
+    async def integral(
+        self,
+        expression: str,
+        *,
+        variable: str,
+        lower_limit: Optional[str] = None,
+        upper_limit: Optional[str] = None,
+        variables: Sequence[str] | None = None,
+        canonicalize: bool = True,
+        timeout: float | None = None,
+    ) -> symbolic_pb2.SymbolicResponse:
+        request = symbolic_pb2.IntegralRequest(
+            expression=expression,
+            variables=list(variables or []),
+            variable=variable,
+            lower_limit=lower_limit,
+            upper_limit=upper_limit,
+            canonicalize=canonicalize,
+        )
+        return await self._stub.Integral(request, timeout=timeout)
+
+    async def solve(
+        self,
+        equation: str,
+        *,
+        variable: str,
+        parameters: Iterable[str] | None = None,
+        canonicalize: bool = True,
+        timeout: float | None = None,
+    ) -> symbolic_pb2.SymbolicResponse:
+        request = symbolic_pb2.SolveRequest(
+            equation=equation,
+            variable=variable,
+            parameters=list(parameters or []),
+            canonicalize=canonicalize,
+        )
+        return await self._stub.Solve(request, timeout=timeout)
+
+    async def series(
+        self,
+        expression: str,
+        *,
+        variable: str,
+        point: str = "0",
+        order: int = 6,
+        variables: Sequence[str] | None = None,
+        canonicalize: bool = True,
+        timeout: float | None = None,
+    ) -> symbolic_pb2.SymbolicResponse:
+        request = symbolic_pb2.SeriesRequest(
+            expression=expression,
+            variables=list(variables or []),
+            variable=variable,
+            point=point,
+            order=order,
+            canonicalize=canonicalize,
+        )
+        return await self._stub.Series(request, timeout=timeout)
+
+    async def codegen(
+        self,
+        expression: str,
+        *,
+        variables: Sequence[str] | None = None,
+        target: str = "c",
+        function_name: str = "symbolic_kernel",
+        emit_header: bool = False,
+        canonicalize: bool = True,
+        timeout: float | None = None,
+    ) -> symbolic_pb2.SymbolicResponse:
+        request = symbolic_pb2.CodegenRequest(
+            expression=expression,
+            variables=list(variables or []),
+            target=target,
+            function_name=function_name,
+            emit_header=emit_header,
+            canonicalize=canonicalize,
+        )
+        return await self._stub.Codegen(request, timeout=timeout)
+
+    async def close(self) -> None:
+        await self._channel.close()

--- a/services/protos/symbolic_engine.proto
+++ b/services/protos/symbolic_engine.proto
@@ -1,0 +1,74 @@
+syntax = "proto3";
+
+package symbolic;
+
+
+message SimplifyRequest {
+  string expression = 1;
+  repeated string variables = 2;
+  bool canonicalize = 3;
+  string method = 4;
+}
+
+message DerivativeRequest {
+  string expression = 1;
+  repeated string variables = 2;
+  string variable = 3;
+  int32 order = 4;
+  bool canonicalize = 5;
+}
+
+message IntegralRequest {
+  string expression = 1;
+  repeated string variables = 2;
+  string variable = 3;
+  string lower_limit = 4;
+  string upper_limit = 5;
+  bool canonicalize = 6;
+}
+
+message SolveRequest {
+  string equation = 1;
+  string variable = 2;
+  repeated string parameters = 3;
+  bool canonicalize = 4;
+}
+
+message SeriesRequest {
+  string expression = 1;
+  repeated string variables = 2;
+  string variable = 3;
+  string point = 4;
+  int32 order = 5;
+  bool canonicalize = 6;
+}
+
+message CodegenRequest {
+  string expression = 1;
+  repeated string variables = 2;
+  string target = 3;
+  string function_name = 4;
+  bool emit_header = 5;
+  bool canonicalize = 6;
+}
+
+message SymbolicMetadataEntry {
+  string key = 1;
+  string value = 2;
+}
+
+message SymbolicResponse {
+  string result = 1;
+  string latex = 2;
+  string canonical_form = 3;
+  repeated SymbolicMetadataEntry metadata = 4;
+}
+
+service SymbolicEngine {
+  rpc Simplify(SimplifyRequest) returns (SymbolicResponse);
+  rpc Derivative(DerivativeRequest) returns (SymbolicResponse);
+  rpc Integral(IntegralRequest) returns (SymbolicResponse);
+  rpc Solve(SolveRequest) returns (SymbolicResponse);
+  rpc Series(SeriesRequest) returns (SymbolicResponse);
+  rpc Codegen(CodegenRequest) returns (SymbolicResponse);
+}

--- a/services/protos/symbolic_engine_pb2.py
+++ b/services/protos/symbolic_engine_pb2.py
@@ -1,0 +1,231 @@
+"""Dataclass representations of the symbolic engine proto messages."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Sequence
+
+
+@dataclass(slots=True)
+class SimplifyRequest:
+    expression: str = ""
+    variables: List[str] = field(default_factory=list)
+    canonicalize: bool = True
+    method: str = ""
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "expression": self.expression,
+            "variables": list(self.variables),
+            "canonicalize": self.canonicalize,
+            "method": self.method,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Dict[str, object]) -> "SimplifyRequest":
+        return cls(
+            expression=str(payload.get("expression", "")),
+            variables=[str(item) for item in payload.get("variables", [])],
+            canonicalize=bool(payload.get("canonicalize", True)),
+            method=str(payload.get("method", "")),
+        )
+
+
+@dataclass(slots=True)
+class DerivativeRequest:
+    expression: str = ""
+    variables: List[str] = field(default_factory=list)
+    variable: str = ""
+    order: int = 1
+    canonicalize: bool = True
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "expression": self.expression,
+            "variables": list(self.variables),
+            "variable": self.variable,
+            "order": self.order,
+            "canonicalize": self.canonicalize,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Dict[str, object]) -> "DerivativeRequest":
+        return cls(
+            expression=str(payload.get("expression", "")),
+            variables=[str(item) for item in payload.get("variables", [])],
+            variable=str(payload.get("variable", "")),
+            order=int(payload.get("order", 1)),
+            canonicalize=bool(payload.get("canonicalize", True)),
+        )
+
+
+@dataclass(slots=True)
+class IntegralRequest:
+    expression: str = ""
+    variables: List[str] = field(default_factory=list)
+    variable: str = ""
+    lower_limit: str | None = None
+    upper_limit: str | None = None
+    canonicalize: bool = True
+
+    def to_dict(self) -> Dict[str, object]:
+        payload: Dict[str, object] = {
+            "expression": self.expression,
+            "variables": list(self.variables),
+            "variable": self.variable,
+            "canonicalize": self.canonicalize,
+        }
+        if self.lower_limit is not None:
+            payload["lower_limit"] = self.lower_limit
+        if self.upper_limit is not None:
+            payload["upper_limit"] = self.upper_limit
+        return payload
+
+    @classmethod
+    def from_dict(cls, payload: Dict[str, object]) -> "IntegralRequest":
+        lower = payload.get("lower_limit")
+        upper = payload.get("upper_limit")
+        return cls(
+            expression=str(payload.get("expression", "")),
+            variables=[str(item) for item in payload.get("variables", [])],
+            variable=str(payload.get("variable", "")),
+            lower_limit=str(lower) if lower is not None else None,
+            upper_limit=str(upper) if upper is not None else None,
+            canonicalize=bool(payload.get("canonicalize", True)),
+        )
+
+
+@dataclass(slots=True)
+class SolveRequest:
+    equation: str = ""
+    variable: str = ""
+    parameters: List[str] = field(default_factory=list)
+    canonicalize: bool = True
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "equation": self.equation,
+            "variable": self.variable,
+            "parameters": list(self.parameters),
+            "canonicalize": self.canonicalize,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Dict[str, object]) -> "SolveRequest":
+        return cls(
+            equation=str(payload.get("equation", "")),
+            variable=str(payload.get("variable", "")),
+            parameters=[str(item) for item in payload.get("parameters", [])],
+            canonicalize=bool(payload.get("canonicalize", True)),
+        )
+
+
+@dataclass(slots=True)
+class SeriesRequest:
+    expression: str = ""
+    variables: List[str] = field(default_factory=list)
+    variable: str = ""
+    point: str = "0"
+    order: int = 6
+    canonicalize: bool = True
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "expression": self.expression,
+            "variables": list(self.variables),
+            "variable": self.variable,
+            "point": self.point,
+            "order": self.order,
+            "canonicalize": self.canonicalize,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Dict[str, object]) -> "SeriesRequest":
+        return cls(
+            expression=str(payload.get("expression", "")),
+            variables=[str(item) for item in payload.get("variables", [])],
+            variable=str(payload.get("variable", "")),
+            point=str(payload.get("point", "0")),
+            order=int(payload.get("order", 6)),
+            canonicalize=bool(payload.get("canonicalize", True)),
+        )
+
+
+@dataclass(slots=True)
+class CodegenRequest:
+    expression: str = ""
+    variables: List[str] = field(default_factory=list)
+    target: str = "c"
+    function_name: str = "symbolic_kernel"
+    emit_header: bool = False
+    canonicalize: bool = True
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "expression": self.expression,
+            "variables": list(self.variables),
+            "target": self.target,
+            "function_name": self.function_name,
+            "emit_header": self.emit_header,
+            "canonicalize": self.canonicalize,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Dict[str, object]) -> "CodegenRequest":
+        return cls(
+            expression=str(payload.get("expression", "")),
+            variables=[str(item) for item in payload.get("variables", [])],
+            target=str(payload.get("target", "c")),
+            function_name=str(payload.get("function_name", "symbolic_kernel")),
+            emit_header=bool(payload.get("emit_header", False)),
+            canonicalize=bool(payload.get("canonicalize", True)),
+        )
+
+
+@dataclass(slots=True)
+class SymbolicMetadataEntry:
+    key: str
+    value: str
+
+    def to_dict(self) -> Dict[str, str]:
+        return {"key": self.key, "value": self.value}
+
+
+@dataclass(slots=True)
+class SymbolicResponse:
+    result: str = ""
+    latex: str | None = None
+    canonical_form: str | None = None
+    metadata: List[SymbolicMetadataEntry] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, object]:
+        payload: Dict[str, object] = {"result": self.result, "metadata": [entry.to_dict() for entry in self.metadata]}
+        if self.latex is not None:
+            payload["latex"] = self.latex
+        if self.canonical_form is not None:
+            payload["canonical_form"] = self.canonical_form
+        return payload
+
+    @classmethod
+    def from_dict(cls, payload: Dict[str, object]) -> "SymbolicResponse":
+        entries = [
+            SymbolicMetadataEntry(key=str(item.get("key", "")), value=str(item.get("value", "")))
+            for item in payload.get("metadata", [])
+        ]
+        return cls(
+            result=str(payload.get("result", "")),
+            latex=str(payload["latex"]) if payload.get("latex") is not None else None,
+            canonical_form=str(payload["canonical_form"]) if payload.get("canonical_form") is not None else None,
+            metadata=entries,
+        )
+
+
+__all__ = [
+    "SimplifyRequest",
+    "DerivativeRequest",
+    "IntegralRequest",
+    "SolveRequest",
+    "SeriesRequest",
+    "CodegenRequest",
+    "SymbolicMetadataEntry",
+    "SymbolicResponse",
+]

--- a/services/protos/symbolic_engine_pb2_grpc.py
+++ b/services/protos/symbolic_engine_pb2_grpc.py
@@ -1,0 +1,130 @@
+"""gRPC stubs for the symbolic engine service."""
+from __future__ import annotations
+
+from typing import Sequence
+
+from services.common.grpc import grpc
+
+from . import symbolic_engine_pb2 as symbolic__pb2
+
+
+class SymbolicEngineStub:
+    """Async client stub for the symbolic engine service."""
+
+    def __init__(self, channel: grpc.aio.Channel) -> None:
+        self._channel = channel
+
+    async def Simplify(
+        self,
+        request: symbolic__pb2.SimplifyRequest,
+        timeout: float | None = None,
+        metadata: Sequence[tuple[str, str]] | None = None,
+    ) -> symbolic__pb2.SymbolicResponse:
+        callable_ = self._channel.unary_unary("/symbolic.SymbolicEngine/Simplify")
+        response_payload = await callable_(request, timeout=timeout, metadata=metadata)
+        return symbolic__pb2.SymbolicResponse.from_dict(response_payload)
+
+    async def Derivative(
+        self,
+        request: symbolic__pb2.DerivativeRequest,
+        timeout: float | None = None,
+        metadata: Sequence[tuple[str, str]] | None = None,
+    ) -> symbolic__pb2.SymbolicResponse:
+        callable_ = self._channel.unary_unary("/symbolic.SymbolicEngine/Derivative")
+        response_payload = await callable_(request, timeout=timeout, metadata=metadata)
+        return symbolic__pb2.SymbolicResponse.from_dict(response_payload)
+
+    async def Integral(
+        self,
+        request: symbolic__pb2.IntegralRequest,
+        timeout: float | None = None,
+        metadata: Sequence[tuple[str, str]] | None = None,
+    ) -> symbolic__pb2.SymbolicResponse:
+        callable_ = self._channel.unary_unary("/symbolic.SymbolicEngine/Integral")
+        response_payload = await callable_(request, timeout=timeout, metadata=metadata)
+        return symbolic__pb2.SymbolicResponse.from_dict(response_payload)
+
+    async def Solve(
+        self,
+        request: symbolic__pb2.SolveRequest,
+        timeout: float | None = None,
+        metadata: Sequence[tuple[str, str]] | None = None,
+    ) -> symbolic__pb2.SymbolicResponse:
+        callable_ = self._channel.unary_unary("/symbolic.SymbolicEngine/Solve")
+        response_payload = await callable_(request, timeout=timeout, metadata=metadata)
+        return symbolic__pb2.SymbolicResponse.from_dict(response_payload)
+
+    async def Series(
+        self,
+        request: symbolic__pb2.SeriesRequest,
+        timeout: float | None = None,
+        metadata: Sequence[tuple[str, str]] | None = None,
+    ) -> symbolic__pb2.SymbolicResponse:
+        callable_ = self._channel.unary_unary("/symbolic.SymbolicEngine/Series")
+        response_payload = await callable_(request, timeout=timeout, metadata=metadata)
+        return symbolic__pb2.SymbolicResponse.from_dict(response_payload)
+
+    async def Codegen(
+        self,
+        request: symbolic__pb2.CodegenRequest,
+        timeout: float | None = None,
+        metadata: Sequence[tuple[str, str]] | None = None,
+    ) -> symbolic__pb2.SymbolicResponse:
+        callable_ = self._channel.unary_unary("/symbolic.SymbolicEngine/Codegen")
+        response_payload = await callable_(request, timeout=timeout, metadata=metadata)
+        return symbolic__pb2.SymbolicResponse.from_dict(response_payload)
+
+
+class SymbolicEngineServicer:
+    """Base servicer implementation expected by the gateway."""
+
+    async def Simplify(self, request: symbolic__pb2.SimplifyRequest, context: grpc.ServicerContext) -> symbolic__pb2.SymbolicResponse:  # noqa: D401,E501
+        raise NotImplementedError
+
+    async def Derivative(self, request: symbolic__pb2.DerivativeRequest, context: grpc.ServicerContext) -> symbolic__pb2.SymbolicResponse:
+        raise NotImplementedError
+
+    async def Integral(self, request: symbolic__pb2.IntegralRequest, context: grpc.ServicerContext) -> symbolic__pb2.SymbolicResponse:
+        raise NotImplementedError
+
+    async def Solve(self, request: symbolic__pb2.SolveRequest, context: grpc.ServicerContext) -> symbolic__pb2.SymbolicResponse:
+        raise NotImplementedError
+
+    async def Series(self, request: symbolic__pb2.SeriesRequest, context: grpc.ServicerContext) -> symbolic__pb2.SymbolicResponse:
+        raise NotImplementedError
+
+    async def Codegen(self, request: symbolic__pb2.CodegenRequest, context: grpc.ServicerContext) -> symbolic__pb2.SymbolicResponse:
+        raise NotImplementedError
+
+
+def add_SymbolicEngineServicer_to_server(servicer: SymbolicEngineServicer, server: grpc.aio.Server) -> None:
+    async def _handle(method_name: str, payload: dict, context: grpc.ServicerContext) -> dict:
+        request_cls = {
+            "Simplify": symbolic__pb2.SimplifyRequest,
+            "Derivative": symbolic__pb2.DerivativeRequest,
+            "Integral": symbolic__pb2.IntegralRequest,
+            "Solve": symbolic__pb2.SolveRequest,
+            "Series": symbolic__pb2.SeriesRequest,
+            "Codegen": symbolic__pb2.CodegenRequest,
+        }[method_name]
+        request = request_cls.from_dict(payload)
+        handler = getattr(servicer, method_name)
+        response = await handler(request, context)
+        return response.to_dict()
+
+    handlers = {}
+    for method_name in ("Simplify", "Derivative", "Integral", "Solve", "Series", "Codegen"):
+        async def _invoker(payload: dict, context: grpc.ServicerContext, *, _method=method_name):
+            return await _handle(_method, payload, context)
+
+        handlers[method_name] = grpc.UnaryUnaryRpcMethodHandler(_invoker)
+
+    generic_handler = grpc.method_handlers_generic_handler("symbolic.SymbolicEngine", handlers)
+    server.add_generic_rpc_handlers([generic_handler])
+
+
+__all__ = [
+    "SymbolicEngineStub",
+    "SymbolicEngineServicer",
+    "add_SymbolicEngineServicer_to_server",
+]

--- a/services/symbolic_engine/Dockerfile
+++ b/services/symbolic_engine/Dockerfile
@@ -1,0 +1,35 @@
+# syntax=docker/dockerfile:1
+
+FROM python:3.11-slim AS builder
+
+WORKDIR /workspace
+
+COPY requirements.txt ./
+
+RUN pip wheel --no-cache-dir --wheel-dir /workspace/wheels -r requirements.txt
+
+FROM python:3.11-slim AS runtime
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+WORKDIR /app
+
+COPY --from=builder /workspace/requirements.txt ./
+COPY --from=builder /workspace/wheels /wheels
+RUN pip install --no-cache-dir /wheels/*
+
+COPY app ./app
+COPY scripts ./scripts
+COPY pyproject.toml ./
+COPY README.md ./
+
+RUN useradd --create-home symbolic && \
+    chown -R symbolic:symbolic /app && \
+    chmod +x /app/scripts/start.sh
+
+USER symbolic
+
+EXPOSE 8082
+
+ENTRYPOINT ["/app/scripts/start.sh"]

--- a/services/symbolic_engine/README.md
+++ b/services/symbolic_engine/README.md
@@ -1,0 +1,18 @@
+# Symbolic Engine Service
+
+The Symbolic Engine is a FastAPI microservice that wraps SymPy-powered operations behind a
+sandboxed execution boundary. It provides REST endpoints for algebraic simplification,
+differentiation, integration, solving, series expansion, and code generation.
+
+## Local Development
+
+```bash
+poetry install
+poetry run uvicorn app.main:app --reload --port 8082
+```
+
+## Running Tests
+
+```bash
+poetry run pytest
+```

--- a/services/symbolic_engine/app/config.py
+++ b/services/symbolic_engine/app/config.py
@@ -1,0 +1,38 @@
+"""Configuration utilities for the Symbolic Engine service."""
+from functools import lru_cache
+from typing import Literal
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Runtime configuration for the Symbolic Engine API."""
+
+    app_name: str = "symbolic-engine"
+    sandbox_timeout_seconds: float = 2.5
+    sandbox_memory_limit_mb: int = 256
+    sandbox_cpu_time_seconds: int = 2
+    sandbox_allowed_modules: tuple[str, ...] = (
+        "sympy",
+        "mpmath",
+        "math",
+        "decimal",
+    )
+    sandbox_blocked_modules: tuple[str, ...] = (
+        "os",
+        "subprocess",
+        "socket",
+        "pathlib",
+        "shutil",
+    )
+    enable_numba_acceleration: bool = False
+    default_codegen_target: Literal["c", "python", "llvm"] = "c"
+
+    model_config = SettingsConfigDict(env_prefix="SYMBOLIC_ENGINE_", extra="ignore")
+
+
+@lru_cache(maxsize=1)
+def get_settings() -> Settings:
+    """Return cached settings instance."""
+
+    return Settings()

--- a/services/symbolic_engine/app/main.py
+++ b/services/symbolic_engine/app/main.py
@@ -1,0 +1,105 @@
+"""FastAPI application exposing symbolic operations."""
+from __future__ import annotations
+
+from fastapi import Depends, FastAPI
+from fastapi.responses import JSONResponse
+
+from .config import Settings, get_settings
+from .sandbox import SandboxExecutionError, run_operation
+from .schemas import (
+    CodegenRequest,
+    DerivativeRequest,
+    ErrorResponse,
+    IntegralRequest,
+    SandboxDiagnostics,
+    SeriesRequest,
+    SimplifyRequest,
+    SolveRequest,
+    SymbolicResponse,
+)
+
+app = FastAPI(title="Symbolic Engine", version="0.1.0")
+
+
+def _build_response(data: dict) -> SymbolicResponse:
+    metadata = data.get("metadata", {})
+    diagnostics = data.get("diagnostics", {})
+    metadata.setdefault("sandbox", diagnostics)
+    return SymbolicResponse(
+        result=data["result"],
+        latex=data.get("latex"),
+        metadata=metadata,
+        canonical_form=data.get("canonical_form"),
+    )
+
+
+@app.exception_handler(SandboxExecutionError)
+async def sandbox_error_handler(_: FastAPI, exc: SandboxExecutionError):  # type: ignore[override]
+    diagnostics_data = exc.diagnostics or {}
+    diagnostics = SandboxDiagnostics(
+        runtime_ms=float(diagnostics_data.get("runtime_ms", 0.0)),
+        module_allowlist=list(diagnostics_data.get("module_allowlist", [])),
+        memory_limit_mb=int(diagnostics_data.get("memory_limit_mb", 0)),
+        cpu_limit_seconds=int(diagnostics_data.get("cpu_limit_seconds", 0)),
+    )
+    error = ErrorResponse(detail=str(exc), diagnostics=diagnostics)
+    return JSONResponse(status_code=400, content=error.model_dump())
+
+
+@app.get("/healthz")
+def health(settings: Settings = Depends(get_settings)) -> dict[str, str]:
+    return {"status": "ok", "service": settings.app_name}
+
+
+@app.post("/v1/simplify", response_model=SymbolicResponse, responses={400: {"model": ErrorResponse}})
+def simplify(
+    request: SimplifyRequest,
+    settings: Settings = Depends(get_settings),
+) -> SymbolicResponse:
+    data = run_operation("simplify", request.model_dump(), settings)
+    return _build_response(data)
+
+
+@app.post("/v1/derivative", response_model=SymbolicResponse, responses={400: {"model": ErrorResponse}})
+def derivative(
+    request: DerivativeRequest,
+    settings: Settings = Depends(get_settings),
+) -> SymbolicResponse:
+    data = run_operation("derivative", request.model_dump(), settings)
+    return _build_response(data)
+
+
+@app.post("/v1/integral", response_model=SymbolicResponse, responses={400: {"model": ErrorResponse}})
+def integral(
+    request: IntegralRequest,
+    settings: Settings = Depends(get_settings),
+) -> SymbolicResponse:
+    data = run_operation("integral", request.model_dump(), settings)
+    return _build_response(data)
+
+
+@app.post("/v1/solve", response_model=SymbolicResponse, responses={400: {"model": ErrorResponse}})
+def solve(
+    request: SolveRequest,
+    settings: Settings = Depends(get_settings),
+) -> SymbolicResponse:
+    data = run_operation("solve", request.model_dump(), settings)
+    return _build_response(data)
+
+
+@app.post("/v1/series", response_model=SymbolicResponse, responses={400: {"model": ErrorResponse}})
+def series(
+    request: SeriesRequest,
+    settings: Settings = Depends(get_settings),
+) -> SymbolicResponse:
+    data = run_operation("series", request.model_dump(), settings)
+    return _build_response(data)
+
+
+@app.post("/v1/codegen", response_model=SymbolicResponse, responses={400: {"model": ErrorResponse}})
+def codegen(
+    request: CodegenRequest,
+    settings: Settings = Depends(get_settings),
+) -> SymbolicResponse:
+    data = run_operation("codegen", request.model_dump(), settings)
+    return _build_response(data)

--- a/services/symbolic_engine/app/operations.py
+++ b/services/symbolic_engine/app/operations.py
@@ -1,0 +1,203 @@
+"""SymPy-powered symbolic operations for the API."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Sequence
+
+import sympy as sp
+from sympy import Eq
+from sympy.printing.latex import latex
+from sympy.utilities.codegen import codegen
+
+
+@dataclass
+class OperationResult:
+    """Container for symbolic results with metadata."""
+
+    result: str
+    latex: str | None
+    canonical_form: str | None
+    metadata: Dict[str, Any]
+
+
+def _create_symbols(variables: Sequence[str]) -> Dict[str, sp.Symbol]:
+    if not variables:
+        return {}
+    sym_list = sp.symbols(list(dict.fromkeys(variables)))
+    if isinstance(sym_list, tuple):
+        return {str(symbol): symbol for symbol in sym_list}
+    return {str(sym_list): sym_list}
+
+
+def _canonical(expr: sp.Expr | Sequence[Any]) -> str:
+    if isinstance(expr, (list, tuple)):
+        return str([_canonical(item) for item in expr])
+    return sp.srepr(sp.simplify(expr))
+
+
+def simplify_expression(
+    expression: str,
+    variables: Sequence[str],
+    method: str | None = None,
+    canonicalize: bool = True,
+) -> OperationResult:
+    symbol_map = _create_symbols(variables)
+    expr = sp.sympify(expression, locals=symbol_map)
+
+    if method == "trigsimp":
+        simplified = sp.trigsimp(expr)
+    elif method == "powsimp":
+        simplified = sp.powsimp(expr)
+    elif method == "expand":
+        simplified = sp.expand(expr)
+    else:
+        simplified = sp.simplify(expr)
+
+    result = str(simplified)
+    result_latex = latex(simplified)
+    canonical_form = _canonical(simplified) if canonicalize else None
+    metadata = {
+        "free_symbols": sorted(str(symbol) for symbol in simplified.free_symbols),
+        "method": method or "simplify",
+    }
+    return OperationResult(result=result, latex=result_latex, canonical_form=canonical_form, metadata=metadata)
+
+
+def differentiate_expression(
+    expression: str,
+    variables: Sequence[str],
+    variable: str,
+    order: int,
+    canonicalize: bool = True,
+) -> OperationResult:
+    symbol_map = _create_symbols([variable, *variables])
+    expr = sp.sympify(expression, locals=symbol_map)
+    symbol = symbol_map[variable]
+    differentiated = sp.diff(expr, symbol, order)
+
+    result = str(differentiated)
+    result_latex = latex(differentiated)
+    canonical_form = _canonical(differentiated) if canonicalize else None
+    metadata = {
+        "free_symbols": sorted(str(symbol) for symbol in differentiated.free_symbols),
+        "variable": variable,
+        "order": order,
+    }
+    return OperationResult(result=result, latex=result_latex, canonical_form=canonical_form, metadata=metadata)
+
+
+def integrate_expression(
+    expression: str,
+    variables: Sequence[str],
+    variable: str,
+    lower_limit: str | None,
+    upper_limit: str | None,
+    canonicalize: bool = True,
+) -> OperationResult:
+    symbol_map = _create_symbols([variable, *variables])
+    expr = sp.sympify(expression, locals=symbol_map)
+    symbol = symbol_map[variable]
+
+    if lower_limit is not None and upper_limit is not None:
+        lower = sp.sympify(lower_limit, locals=symbol_map)
+        upper = sp.sympify(upper_limit, locals=symbol_map)
+        integrated = sp.integrate(expr, (symbol, lower, upper))
+    else:
+        integrated = sp.integrate(expr, symbol)
+
+    result = str(integrated)
+    result_latex = latex(integrated)
+    canonical_form = _canonical(integrated) if canonicalize else None
+    metadata = {
+        "free_symbols": sorted(str(symbol) for symbol in integrated.free_symbols),
+        "variable": variable,
+        "definite": lower_limit is not None and upper_limit is not None,
+    }
+    if lower_limit is not None:
+        metadata["lower_limit"] = lower_limit
+    if upper_limit is not None:
+        metadata["upper_limit"] = upper_limit
+    return OperationResult(result=result, latex=result_latex, canonical_form=canonical_form, metadata=metadata)
+
+
+def solve_equation(
+    equation: str,
+    variable: str,
+    parameters: Iterable[str],
+    canonicalize: bool = True,
+) -> OperationResult:
+    symbol_map = _create_symbols([variable, *parameters])
+
+    if "=" in equation:
+        left, right = equation.split("=", maxsplit=1)
+        left_expr = sp.sympify(left, locals=symbol_map)
+        right_expr = sp.sympify(right, locals=symbol_map)
+        expr = Eq(left_expr, right_expr)
+        solutions = sp.solve(expr, symbol_map[variable])
+    else:
+        expr = sp.sympify(equation, locals=symbol_map)
+        solutions = sp.solve(expr, symbol_map[variable])
+
+    canonical_form = _canonical(solutions) if canonicalize else None
+    metadata = {
+        "solution_count": len(solutions),
+        "variable": variable,
+    }
+    result = str(solutions)
+    result_latex = latex(sp.Tuple(*solutions)) if solutions else None
+    return OperationResult(result=result, latex=result_latex, canonical_form=canonical_form, metadata=metadata)
+
+
+def series_expansion(
+    expression: str,
+    variables: Sequence[str],
+    variable: str,
+    point: str,
+    order: int,
+    canonicalize: bool = True,
+) -> OperationResult:
+    symbol_map = _create_symbols([variable, *variables])
+    expr = sp.sympify(expression, locals=symbol_map)
+    symbol = symbol_map[variable]
+    expansion_point = sp.sympify(point, locals=symbol_map)
+    series_obj = sp.series(expr, symbol, expansion_point, order)
+
+    result = str(series_obj)
+    result_latex = latex(series_obj.removeO())
+    canonical_form = _canonical(series_obj.removeO()) if canonicalize else None
+    metadata = {
+        "variable": variable,
+        "point": str(expansion_point),
+        "order": order,
+    }
+    return OperationResult(result=result, latex=result_latex, canonical_form=canonical_form, metadata=metadata)
+
+
+def generate_code(
+    expression: str,
+    variables: Sequence[str],
+    target: str,
+    function_name: str,
+    emit_header: bool,
+    canonicalize: bool = True,
+) -> OperationResult:
+    symbol_map = _create_symbols(variables)
+    expr = sp.sympify(expression, locals=symbol_map)
+
+    codegen_name = function_name or "symbolic_kernel"
+    code_artifacts = codegen((codegen_name, expr), language=target, header=emit_header)
+
+    artifact_map: List[Dict[str, str]] = []
+    for artifact_name, artifact_content in code_artifacts:
+        artifact_map.append({"name": artifact_name, "content": artifact_content})
+
+    canonical_form = _canonical(expr) if canonicalize else None
+    metadata = {
+        "target": target,
+        "function_name": codegen_name,
+        "artifacts": artifact_map,
+        "numba_ready": target in {"c", "llvm"},
+    }
+
+    result_latex = latex(expr)
+    return OperationResult(result=str(expr), latex=result_latex, canonical_form=canonical_form, metadata=metadata)

--- a/services/symbolic_engine/app/sandbox.py
+++ b/services/symbolic_engine/app/sandbox.py
@@ -1,0 +1,110 @@
+"""Sandbox execution helpers for the symbolic engine."""
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict
+
+from .config import Settings, get_settings
+
+
+class SandboxExecutionError(RuntimeError):
+    """Raised when the sandbox cannot produce a valid result."""
+
+    def __init__(self, message: str, diagnostics: Dict[str, Any] | None = None) -> None:
+        super().__init__(message)
+        self.diagnostics = diagnostics or {}
+
+
+_SUSPICIOUS_PATTERNS = (
+    re.compile(r"__"),
+    re.compile(r"\bimport\b", re.IGNORECASE),
+    re.compile(r"\beval\b", re.IGNORECASE),
+    re.compile(r"\bexec\b", re.IGNORECASE),
+    re.compile(r"\bos\b", re.IGNORECASE),
+    re.compile(r"\bsubprocess\b", re.IGNORECASE),
+)
+
+
+def _ensure_safe_payload(payload: Dict[str, Any]) -> None:
+    """Validate that user supplied strings do not contain unsafe tokens."""
+
+    for key, value in payload.items():
+        if isinstance(value, str):
+            for pattern in _SUSPICIOUS_PATTERNS:
+                if pattern.search(value):
+                    msg = f"Field '{key}' contains disallowed token for sandbox execution."
+                    raise SandboxExecutionError(msg)
+        elif isinstance(value, dict):
+            _ensure_safe_payload(value)
+        elif isinstance(value, (list, tuple)):
+            for item in value:
+                if isinstance(item, (str, dict, list, tuple)):
+                    _ensure_safe_payload({"nested": item} if not isinstance(item, str) else {"nested": item})
+
+
+def run_operation(operation: str, payload: Dict[str, Any], settings: Settings | None = None) -> Dict[str, Any]:
+    """Execute an operation within the sandbox runner."""
+
+    config = settings or get_settings()
+    _ensure_safe_payload(payload)
+
+    runner_module = "services.symbolic_engine.app.sandbox_runner"
+    command = [sys.executable, "-m", runner_module, operation]
+
+    cwd = Path(__file__).resolve().parents[2]
+    start_time = time.monotonic()
+    try:
+        completed = subprocess.run(
+            command,
+            input=json.dumps({"payload": payload, "config": config.dict()}),
+            cwd=cwd,
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=config.sandbox_timeout_seconds,
+        )
+    except subprocess.TimeoutExpired as exc:  # pragma: no cover - relies on system timing
+        raise SandboxExecutionError("Sandbox execution timed out.") from exc
+
+    runtime_ms = (time.monotonic() - start_time) * 1000
+
+    if completed.returncode != 0:
+        stderr = completed.stderr.strip()
+        raise SandboxExecutionError(
+            "Sandbox process exited with failure.",
+            diagnostics={
+                "stderr": stderr,
+                "runtime_ms": runtime_ms,
+                "return_code": completed.returncode,
+            },
+        )
+
+    try:
+        data = json.loads(completed.stdout or "{}")
+    except json.JSONDecodeError as exc:  # pragma: no cover - indicates runner bug
+        raise SandboxExecutionError("Failed to decode sandbox output.") from exc
+
+    if "error" in data:
+        raise SandboxExecutionError(
+            data["error"],
+            diagnostics={
+                **{k: v for k, v in data.get("diagnostics", {}).items()},
+                "runtime_ms": runtime_ms,
+            },
+        )
+
+    data.setdefault("diagnostics", {})
+    data["diagnostics"].update(
+        {
+            "runtime_ms": runtime_ms,
+            "module_allowlist": list(config.sandbox_allowed_modules),
+            "memory_limit_mb": config.sandbox_memory_limit_mb,
+            "cpu_limit_seconds": config.sandbox_cpu_time_seconds,
+        }
+    )
+    return data

--- a/services/symbolic_engine/app/sandbox_runner.py
+++ b/services/symbolic_engine/app/sandbox_runner.py
@@ -1,0 +1,169 @@
+"""Entry point executed inside the sandbox subprocess."""
+from __future__ import annotations
+
+import json
+import resource
+import signal
+import sys
+import time
+from dataclasses import asdict
+from typing import Any, Dict
+
+from . import operations
+from .config import Settings
+
+
+class SandboxFailure(Exception):
+    """Internal sandbox exception."""
+
+
+def _apply_resource_limits(settings: Settings) -> None:
+    """Apply CPU and memory resource ceilings."""
+
+    memory_bytes = settings.sandbox_memory_limit_mb * 1024 * 1024
+    resource.setrlimit(resource.RLIMIT_AS, (memory_bytes, memory_bytes))
+    resource.setrlimit(resource.RLIMIT_CPU, (settings.sandbox_cpu_time_seconds, settings.sandbox_cpu_time_seconds))
+
+
+def _install_signal_handlers(settings: Settings) -> None:
+    """Install fail-fast signal handlers."""
+
+    def _handler(signum: int, _: Any) -> None:
+        raise SandboxFailure(f"Sandbox interrupted by signal {signum}.")
+
+    signal.signal(signal.SIGXCPU, _handler)
+    signal.signal(signal.SIGTERM, _handler)
+
+
+def _guard_imports(settings: Settings) -> None:
+    """Disallow importing unsafe modules within the sandbox."""
+
+    blocked = set(settings.sandbox_blocked_modules)
+    builtins_obj = __builtins__
+    if isinstance(builtins_obj, dict):
+        original_import = builtins_obj["__import__"]
+    else:
+        original_import = builtins_obj.__import__  # type: ignore[attr-defined]
+
+    def _restricted_import(name: str, globals: Dict[str, Any] | None = None, locals: Dict[str, Any] | None = None, fromlist: Any = (), level: int = 0):  # noqa: D417, ANN001
+        root = name.split(".", 1)[0]
+        if root in blocked:
+            msg = f"Module '{root}' is not permitted in the symbolic sandbox."
+            raise ImportError(msg)
+        return original_import(name, globals, locals, fromlist, level)
+
+    if isinstance(builtins_obj, dict):
+        builtins_obj["__import__"] = _restricted_import
+    else:  # pragma: no cover - exercised at runtime only
+        builtins_obj.__import__ = _restricted_import  # type: ignore[attr-defined]
+
+
+def _success_payload(result: operations.OperationResult, diagnostics: Dict[str, Any]) -> Dict[str, Any]:
+    payload = asdict(result)
+    payload["diagnostics"] = diagnostics
+    return payload
+
+
+def _execute(operation: str, payload: Dict[str, Any], settings: Settings) -> Dict[str, Any]:
+    """Dispatch the requested symbolic operation."""
+
+    canonicalize = payload.get("canonicalize", True)
+    if operation == "simplify":
+        request = payload
+        op_result = operations.simplify_expression(
+            expression=request["expression"],
+            variables=request.get("variables", []),
+            method=request.get("method"),
+            canonicalize=canonicalize,
+        )
+    elif operation == "derivative":
+        request = payload
+        op_result = operations.differentiate_expression(
+            expression=request["expression"],
+            variables=request.get("variables", []),
+            variable=request["variable"],
+            order=request.get("order", 1),
+            canonicalize=canonicalize,
+        )
+    elif operation == "integral":
+        request = payload
+        op_result = operations.integrate_expression(
+            expression=request["expression"],
+            variables=request.get("variables", []),
+            variable=request["variable"],
+            lower_limit=request.get("lower_limit"),
+            upper_limit=request.get("upper_limit"),
+            canonicalize=canonicalize,
+        )
+    elif operation == "solve":
+        request = payload
+        op_result = operations.solve_equation(
+            equation=request["equation"],
+            variable=request["variable"],
+            parameters=request.get("parameters", []),
+            canonicalize=canonicalize,
+        )
+    elif operation == "series":
+        request = payload
+        op_result = operations.series_expansion(
+            expression=request["expression"],
+            variables=request.get("variables", []),
+            variable=request["variable"],
+            point=request.get("point", "0"),
+            order=request.get("order", 6),
+            canonicalize=canonicalize,
+        )
+    elif operation == "codegen":
+        request = payload
+        op_result = operations.generate_code(
+            expression=request["expression"],
+            variables=request.get("variables", []),
+            target=request.get("target", settings.default_codegen_target),
+            function_name=request.get("function_name", "symbolic_kernel"),
+            emit_header=request.get("emit_header", False),
+            canonicalize=canonicalize,
+        )
+    else:  # pragma: no cover - validated before invocation
+        raise SandboxFailure(f"Unsupported operation '{operation}'.")
+
+    return _success_payload(op_result, diagnostics={})
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print(json.dumps({"error": "Operation argument required."}))
+        sys.exit(1)
+
+    operation = sys.argv[1]
+    raw = sys.stdin.read() or "{}"
+
+    try:
+        parsed = json.loads(raw)
+        payload = parsed.get("payload", {})
+        settings = Settings(**parsed.get("config", {}))
+    except Exception as exc:  # pragma: no cover - indicates upstream bug
+        print(json.dumps({"error": f"Invalid sandbox payload: {exc}"}))
+        sys.exit(1)
+
+    diagnostics: Dict[str, Any] = {}
+    try:
+        _apply_resource_limits(settings)
+        _install_signal_handlers(settings)
+        _guard_imports(settings)
+        start = time.monotonic()
+        result = _execute(operation, payload, settings)
+        diagnostics = result.get("diagnostics", {})
+        diagnostics["runtime_ms"] = (time.monotonic() - start) * 1000
+        result["diagnostics"] = diagnostics
+    except SandboxFailure as exc:
+        print(json.dumps({"error": str(exc), "diagnostics": diagnostics}))
+        sys.exit(1)
+    except Exception as exc:  # pragma: no cover - ensures crash safety
+        print(json.dumps({"error": f"Unhandled sandbox error: {exc}", "diagnostics": diagnostics}))
+        sys.exit(1)
+    else:
+        print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/services/symbolic_engine/app/schemas.py
+++ b/services/symbolic_engine/app/schemas.py
@@ -1,0 +1,136 @@
+"""Pydantic models for the Symbolic Engine API."""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Literal, Optional, Sequence
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class SymbolicBaseRequest(BaseModel):
+    """Common fields shared across symbolic operations."""
+
+    expression: str = Field(..., description="Expression to process using SymPy.")
+    variables: Sequence[str] = Field(
+        default_factory=list,
+        description="Ordered list of symbolic variables referenced by the expression.",
+    )
+    canonicalize: bool = Field(
+        default=True,
+        description="Whether to compute a canonical representation for caching.",
+    )
+
+    @field_validator("expression")
+    @classmethod
+    def expression_not_empty(cls, value: str) -> str:  # noqa: D417
+        if not value.strip():
+            msg = "Expression payload must not be empty."
+            raise ValueError(msg)
+        return value
+
+
+class SimplifyRequest(SymbolicBaseRequest):
+    method: Optional[Literal["simplify", "trigsimp", "powsimp", "expand"]] = Field(
+        default=None,
+        description="Optional simplification strategy. Defaults to SymPy's generic simplify.",
+    )
+
+
+class DerivativeRequest(SymbolicBaseRequest):
+    variable: str = Field(..., description="Symbol with respect to which the derivative is taken.")
+    order: int = Field(
+        default=1,
+        ge=1,
+        le=6,
+        description="Order of the derivative (1 for first derivative).",
+    )
+
+
+class IntegralRequest(SymbolicBaseRequest):
+    variable: str = Field(..., description="Integration variable.")
+    lower_limit: Optional[str] = Field(
+        default=None,
+        description="Optional lower limit for definite integrals.",
+    )
+    upper_limit: Optional[str] = Field(
+        default=None,
+        description="Optional upper limit for definite integrals.",
+    )
+
+
+class SolveRequest(BaseModel):
+    equation: str = Field(..., description="Equation to solve; interpreted as equation == 0 if '=' absent.")
+    variable: str = Field(..., description="Symbol to solve for.")
+    parameters: Sequence[str] = Field(
+        default_factory=list,
+        description="Additional symbols treated as parameters (not solved for).",
+    )
+    canonicalize: bool = Field(
+        default=True,
+        description="Whether to compute canonical representation for caching.",
+    )
+
+    @field_validator("equation")
+    @classmethod
+    def equation_not_empty(cls, value: str) -> str:  # noqa: D417
+        if not value.strip():
+            msg = "Equation payload must not be empty."
+            raise ValueError(msg)
+        return value
+
+
+class SeriesRequest(SymbolicBaseRequest):
+    variable: str = Field(..., description="Expansion variable.")
+    point: str = Field(
+        default="0",
+        description="Expansion point; parsed via SymPy sympify.",
+    )
+    order: int = Field(
+        default=6,
+        ge=2,
+        le=20,
+        description="Series order (number of terms including remainder order).",
+    )
+
+
+class CodegenRequest(SymbolicBaseRequest):
+    target: Literal["c", "python", "fortran", "llvm"] = Field(
+        default="c",
+        description="Output language target for the generated code.",
+    )
+    function_name: str = Field(
+        default="symbolic_kernel",
+        description="Function name used during code generation.",
+    )
+    emit_header: bool = Field(
+        default=False,
+        description="Whether to emit header artifacts when supported by the backend.",
+    )
+
+
+class SymbolicResponse(BaseModel):
+    result: str = Field(..., description="Primary symbolic result rendered as a string.")
+    latex: Optional[str] = Field(
+        default=None,
+        description="LaTeX rendering of the symbolic result when available.",
+    )
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+    canonical_form: Optional[str] = Field(
+        default=None,
+        description="Canonical representation (typically SymPy srepr) for cache lookups.",
+    )
+
+
+class SandboxDiagnostics(BaseModel):
+    """Details describing sandbox execution metadata."""
+
+    runtime_ms: float = Field(..., description="Execution wall time in milliseconds.")
+    module_allowlist: List[str] = Field(
+        ..., description="Modules permitted within the sandbox invocation."
+    )
+    memory_limit_mb: int = Field(..., description="Sandbox memory ceiling in megabytes.")
+    cpu_limit_seconds: int = Field(..., description="Sandbox CPU time limit in seconds.")
+
+
+class ErrorResponse(BaseModel):
+    detail: str = Field(..., description="Human-readable error message.")
+    diagnostics: Optional[SandboxDiagnostics] = None

--- a/services/symbolic_engine/pyproject.toml
+++ b/services/symbolic_engine/pyproject.toml
@@ -1,0 +1,37 @@
+[build-system]
+requires = ["poetry-core>=1.9.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry]
+name = "symbolic-engine"
+version = "0.1.0"
+description = "FastAPI microservice for symbolic computation using SymPy"
+authors = ["Calculator Platform Team"]
+readme = "README.md"
+packages = [{ include = "app" }]
+
+[tool.poetry.dependencies]
+python = "^3.10"
+fastapi = "^0.111.0"
+uvicorn = {version = "^0.30.0", extras = ["standard"]}
+sympy = "^1.12"
+pydantic = "^2.7.0"
+pydantic-settings = "^2.4.0"
+numba = "^0.60.0"
+grpcio = "^1.62.0"
+grpcio-tools = "^1.62.0"
+python-json-logger = "^2.0.7"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.2.0"
+pytest-asyncio = "^0.23.0"
+httpx = "^0.27.0"
+ruff = "^0.6.0"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-q"
+
+[tool.ruff]
+target-version = "py310"
+line-length = 100

--- a/services/symbolic_engine/requirements.txt
+++ b/services/symbolic_engine/requirements.txt
@@ -1,0 +1,9 @@
+fastapi==0.111.0
+uvicorn[standard]==0.30.1
+sympy==1.12
+pydantic==2.7.1
+pydantic-settings==2.4.0
+numba==0.60.0
+grpcio==1.62.2
+grpcio-tools==1.62.2
+python-json-logger==2.0.7

--- a/services/symbolic_engine/scripts/start.sh
+++ b/services/symbolic_engine/scripts/start.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export PYTHONPATH="/app:${PYTHONPATH:-}"
+exec uvicorn app.main:app --host 0.0.0.0 --port "${PORT:-8082}" --log-level info

--- a/services/symbolic_engine/tests/conftest.py
+++ b/services/symbolic_engine/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/services/symbolic_engine/tests/test_api.py
+++ b/services/symbolic_engine/tests/test_api.py
@@ -1,0 +1,29 @@
+from fastapi.testclient import TestClient
+
+from services.symbolic_engine.app.main import app
+
+
+client = TestClient(app)
+
+
+def test_simplify_endpoint_returns_canonical_form():
+    response = client.post(
+        "/v1/simplify",
+        json={"expression": "x + x", "variables": ["x"], "canonicalize": True},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["result"] == "2*x"
+    assert "sandbox" in data["metadata"]
+    assert data["canonical_form"] is not None
+
+
+def test_sandbox_guard_error_response():
+    response = client.post(
+        "/v1/simplify",
+        json={"expression": "__import__('os')", "variables": []},
+    )
+    assert response.status_code == 400
+    data = response.json()
+    assert "detail" in data
+    assert data["diagnostics"]["memory_limit_mb"] > 0

--- a/services/symbolic_engine/tests/test_operations.py
+++ b/services/symbolic_engine/tests/test_operations.py
@@ -1,0 +1,47 @@
+import sympy as sp
+
+from services.symbolic_engine.app import operations
+
+
+def test_simplify_expression_polynomial():
+    result = operations.simplify_expression("x**2 + 2*x + 1", ["x"], canonicalize=True)
+    assert sp.simplify(result.result) == sp.simplify("x**2 + 2*x + 1")
+    assert "free_symbols" in result.metadata
+    assert result.canonical_form is not None
+
+
+def test_derivative_expression_basic():
+    result = operations.differentiate_expression("sin(x)", ["x"], variable="x", order=1)
+    assert result.result == "cos(x)"
+    assert result.metadata["order"] == 1
+
+
+def test_integral_expression_definite():
+    result = operations.integrate_expression(
+        "x",
+        ["x"],
+        variable="x",
+        lower_limit="0",
+        upper_limit="2",
+        canonicalize=True,
+    )
+    assert result.result == "2"
+    assert result.metadata["definite"] is True
+
+
+def test_solve_equation_linear():
+    result = operations.solve_equation("x - 4", variable="x", parameters=[], canonicalize=True)
+    assert "4" in result.result
+    assert result.metadata["solution_count"] == 1
+
+
+def test_series_expansion():
+    result = operations.series_expansion("sin(x)", ["x"], variable="x", point="0", order=4)
+    assert "x - x**3/6" in result.result
+    assert result.metadata["order"] == 4
+
+
+def test_codegen_generates_artifacts():
+    result = operations.generate_code("x + y", ["x", "y"], target="c", function_name="f", emit_header=False)
+    assert result.metadata["target"] == "c"
+    assert any("content" in artifact for artifact in result.metadata["artifacts"])

--- a/services/symbolic_engine/tests/test_sandbox.py
+++ b/services/symbolic_engine/tests/test_sandbox.py
@@ -1,0 +1,18 @@
+import pytest
+
+from services.symbolic_engine.app import sandbox
+from services.symbolic_engine.app.config import get_settings
+
+
+def test_run_operation_simplify_returns_metadata():
+    settings = get_settings()
+    data = sandbox.run_operation("simplify", {"expression": "x + x", "variables": ["x"]}, settings)
+    assert "result" in data
+    assert data["result"] == "2*x"
+    diagnostics = data.get("diagnostics", {})
+    assert diagnostics["memory_limit_mb"] == settings.sandbox_memory_limit_mb
+
+
+def test_run_operation_blocks_unsafe_tokens():
+    with pytest.raises(sandbox.SandboxExecutionError):
+        sandbox.run_operation("simplify", {"expression": "__import__('os')", "variables": []})


### PR DESCRIPTION
## Summary
- add the Phase 3 symbolic engine FastAPI service with SymPy-powered operations, sandbox execution, and per-operation endpoints
- define the symbolic_engine gRPC contract, Python stubs, and a gateway client plus add a symbolic cache Alembic migration
- document run instructions, seccomp follow-up, roadmap status, and record the decision to pair SymPy with a sandboxed subprocess

## Testing
- poetry -C services/symbolic_engine run pytest tests *(fails: sympy not installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4b2660174832db8269ab6e06defb0